### PR TITLE
Fix: 아카이브 탭 이중스크롤 / 불필요한 padding 삭제

### DIFF
--- a/components/Molecules/TopTabView.tsx
+++ b/components/Molecules/TopTabView.tsx
@@ -38,7 +38,13 @@ export default function TopTabView({
 
   return (
     <>
-      <Box ref={ref} padding="0 15px" background={theme.colors.white}>
+      <Box
+        ref={ref}
+        position="sticky"
+        top="45px"
+        background={theme.colors.white}
+        zIndex={2}
+      >
         <Box height="45px" overflow="auto" display="flex" zIndex={2}>
           {data.map((item, _index) => (
             <Box
@@ -73,6 +79,7 @@ export default function TopTabView({
       </Box>
       <SwipeableViews
         enableMouseEvents
+        animateHeight={true}
         index={index}
         onChangeIndex={(_index) => {
           setIndex(_index);
@@ -80,7 +87,7 @@ export default function TopTabView({
         style={{
           background: `${theme.colors.white}`,
           width: '100%',
-          height: `calc(100vh - ${headerSize}px`,
+          // height: `calc(100vh - ${headerSize}px`,
         }}
       >
         {data.map((item) =>

--- a/components/Organisms/Detail/Description.tsx
+++ b/components/Organisms/Detail/Description.tsx
@@ -20,9 +20,9 @@ export default function Description() {
         <Box
           position="relative"
           top="390px"
-          backgroundColor={theme.colors.white}
-          borderRadius="24px 24px 0px 0px"
-          overflow="hidden"
+          // backgroundColor={theme.colors.white}
+          // borderRadius="24px 24px 0px 0px"
+          // overflow="hidden"
         >
           <BottomSheetHeader />
           <Box backgroundColor={theme.colors.white} padding="0 15px 60px">

--- a/components/Organisms/Detail/Description/BottomSheetHeader.tsx
+++ b/components/Organisms/Detail/Description/BottomSheetHeader.tsx
@@ -2,5 +2,11 @@ import { Box } from 'components/Atoms';
 import theme from 'styles/theme';
 
 export default function BottomSheetHeader() {
-  return <Box height="25px" backgroundColor={theme.colors.white} />;
+  return (
+    <Box
+      height="25px"
+      backgroundColor={theme.colors.white}
+      borderRadius="24px 24px 0px 0px"
+    />
+  );
 }

--- a/components/Organisms/Detail/Description/Introduce.tsx
+++ b/components/Organisms/Detail/Description/Introduce.tsx
@@ -17,7 +17,7 @@ export default function Introduce({ data }: IntroduceProps) {
       fontSize="13px"
       lineHeight="1.54"
       textAlign="left"
-      padding="40px 15px"
+      padding="40px 0px"
     >
       {showMore ? (
         <Box>


### PR DESCRIPTION
## **📄 PR 카테고리**

- ⬜️ 리팩토링
- ✅ 화면 개발 ( 추가, 수정, 삭제 )
- ⬜️QA 및 버그 수정
- ⬜️ 기타 ( 버전 업데이트 등 )

## **⌨️ 변경점**
1. 아카이브 이중 스크롤 생기는 현상을 수정하였습니다.
> tab을 display: sticky를 사용
2. 불필요한 padding을 삭제하였습니다.

## **🤦🏻 고민한 부분**

## **🙋🏼‍♀️ 추가 논의가 필요한 부분**

## **✋ 추가 코멘트**
