### PR TITLE
swipeableViews 컨텐츠 높이 계산 수정

### DIFF
--- a/components/Molecules/TopTabView.tsx
+++ b/components/Molecules/TopTabView.tsx
@@ -28,6 +28,7 @@ export default function TopTabView({
 }: TopTabViewProps) {
   const [index, setIndex] = useState(0);
   const [headerSize, setHeaderSize] = useState(0);
+  const [checkHeight, setCheckHeight] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -65,6 +66,7 @@ export default function TopTabView({
               `}
               onClick={() => {
                 setIndex(_index);
+                setCheckHeight(true);
               }}
               color={
                 _index === index
@@ -79,7 +81,7 @@ export default function TopTabView({
       </Box>
       <SwipeableViews
         enableMouseEvents
-        animateHeight={true}
+        animateHeight={checkHeight}
         index={index}
         onChangeIndex={(_index) => {
           setIndex(_index);


### PR DESCRIPTION
## **📄 PR 카테고리**

- ⬜️ 리팩토링
- ⬜️ 화면 개발 ( 추가, 수정, 삭제 )
- ✅ QA 및 버그 수정
- ⬜️ 기타 ( 버전 업데이트 등 )

## **⌨️ 변경점**
* 이중 스크롤을 제거하면서 SwipeableViews 에서 제공하는 컨텐츠 높이를 계산해주는 api가 오류
 > tab변경시 api의 true/false 값 usestate로 관리

## **🤦🏻 고민한 부분**

## **🙋🏼‍♀️ 추가 논의가 필요한 부분**

## **✋ 추가 코멘트**
