### PR TITLE
전반적인 css 수정

### DIFF
--- a/assets/common/bottomTabNavigator/NavWish.tsx
+++ b/assets/common/bottomTabNavigator/NavWish.tsx
@@ -3,13 +3,14 @@ export default function NavWish({
   height = '30',
   fill = 'none',
   stroke = '#000',
+  viewBox = '0 0 30 30',
 }) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
       width={width}
       height={height}
-      viewBox="0 0 30 30"
+      viewBox={viewBox}
     >
       <path data-name="사각형 10" fill="none" d="M0 0h30v30H0z" />
       <path

--- a/assets/common/header/ArrowLeft.tsx
+++ b/assets/common/header/ArrowLeft.tsx
@@ -1,10 +1,14 @@
-export default function ArrowLeft({ width = '10', height = '17' }) {
+export default function ArrowLeft({
+  width = '10',
+  height = '17',
+  viewBox = '0 0 9.737 17.116',
+}) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
       width={width}
       height={height}
-      viewBox="0 0 9.737 17.116"
+      viewBox={viewBox}
     >
       <path
         data-name="패스 1383"

--- a/assets/common/header/HeaderHome.tsx
+++ b/assets/common/header/HeaderHome.tsx
@@ -2,13 +2,14 @@ export default function HeaderHome({
   width = '18',
   height = '18',
   fill = '#000',
+  viewBox = '0 0 17.637 18.708',
 }) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
       width={width}
       height={height}
-      viewBox="0 0 17.637 18.708"
+      viewBox={viewBox}
     >
       <path
         data-name="패스 1381"

--- a/assets/common/header/Search.tsx
+++ b/assets/common/header/Search.tsx
@@ -1,10 +1,15 @@
-export default function Search({ width = '18', height = '18', fill = '#000' }) {
+export default function Search({
+  width = '18',
+  height = '18',
+  fill = '#000',
+  viewBox = '0 0 18.964 18.964',
+}) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
       width={width}
       height={height}
-      viewBox="0 0 18.964 18.964"
+      viewBox={viewBox}
     >
       <g data-name="*search">
         <path

--- a/assets/list/ListWish.tsx
+++ b/assets/list/ListWish.tsx
@@ -3,13 +3,14 @@ export default function ListWish({
   height = '8.44',
   fill = '#999',
   stroke = '#999',
+  viewBox = '0 0 9.2 8.44',
 }) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
       width={width}
       height={height}
-      viewBox="0 0 9.2 8.44"
+      viewBox={viewBox}
     >
       <path
         data-name="*heart"

--- a/assets/list/StarRating.tsx
+++ b/assets/list/StarRating.tsx
@@ -2,13 +2,14 @@ export default function StarRating({
   width = '10',
   height = '9.511',
   fill = '#999',
+  viewBox = '0 0 10 9.511',
 }) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
       width={width}
       height={height}
-      viewBox="0 0 10 9.511"
+      viewBox={viewBox}
     >
       <path
         data-name="*star"

--- a/assets/mypage/index.tsx
+++ b/assets/mypage/index.tsx
@@ -1,13 +1,14 @@
 import Image from 'next/image';
 
+import { Folder } from './Folder';
+import { Pointer } from './Pointer';
+
 import apple from 'assets/mypage/apple.png';
 import logo from 'assets/mypage/logo.png';
 import naver from 'assets/mypage/naver.png';
-import { Profile } from 'assets/mypage/Profile';
 import { Photo } from 'assets/mypage/Photo';
+import { Profile } from 'assets/mypage/Profile';
 import { Box } from 'components/Atoms';
-import { Pointer } from './Pointer';
-import { Folder } from './Folder';
 
 interface MyPageImageAssetProps {
   type: 'apple' | 'logo' | 'naver';

--- a/components/Atoms/Tag.tsx
+++ b/components/Atoms/Tag.tsx
@@ -15,10 +15,12 @@ interface TagProps {
 }
 
 const Tag = styled(Span)<BackgroundProps | ColorProps | BorderProps | TagProps>`
-  padding: 4px 12px;
+  display: inline-block;
+  padding: 0px 12px;
   border-radius: 11px;
   font-weight: 500;
   font-size: 11px;
+  line-height: 20px;
   margin-right: 5px;
   ${color}
   ${background}

--- a/components/Molecules/DescriptionInfo.tsx
+++ b/components/Molecules/DescriptionInfo.tsx
@@ -38,11 +38,11 @@ export default function DescriptionInfo({
   };
   return (
     <FlexBox marginBottom="20px" fontSize="13px">
-      <Box flex={0.5}>
+      <Box flex="0 0 75px" fontWeight="500" lineHeight="20px">
         {title === '홈페이지' || title === '티켓구매' ? null : title}
         {/* {title} */}
       </Box>
-      <Box flex={2}>{showDescription()}</Box>
+      <Box lineHeight="20px">{showDescription()}</Box>
     </FlexBox>
   );
 }

--- a/components/Organisms/Common/HeaderBar.tsx
+++ b/components/Organisms/Common/HeaderBar.tsx
@@ -13,19 +13,19 @@ import { headerState } from 'states/common';
 import useRefUtils from 'utils/hooks/useRefUtils';
 
 const headerLeftIcon = {
-  default: <ArrowLeft />,
+  default: <ArrowLeft width="30" height="30" viewBox="-10 -6 30 30" />,
   logo: <>logo</>,
   disabled: <></>,
 };
 
 const headerRightIcon = {
-  search: <Search />,
+  search: <Search width="30" height="30" viewBox="-6 -6 30 30" />,
   disabled: <></>,
 };
 
 const headerEndIcon = {
   disabled: <></>,
-  home: <HeaderHome />,
+  home: <HeaderHome width="30" height="30" viewBox="-6 -5 30 30" />,
 };
 
 function HeaderBar() {
@@ -50,26 +50,30 @@ function HeaderBar() {
           content="내 근처 문화생활 로드맵, KM 킬로미터"
         />
       </Head>
-      <FlexBox
+      <Box
         ref={ref}
         role="menubar"
         position="fixed"
-        padding="14px 15px"
+        // padding="14px 15px"
         top="0px"
         width="100%"
         height="45px"
-        alignItems="center"
+        // alignItems="center"
         background="white"
         zIndex={Z_INDEX.SKY}
       >
         <Box
-          flex={1}
+          // flex={1}
           aria-label="왼쪽 버튼"
           role="button"
-          width="80px"
-          justifyContent="flex-start"
-          height="100%"
-          alignItems="center"
+          position="absolute"
+          top="6px"
+          left="5px"
+          width="30px"
+          height="30px"
+          // justifyContent="flex-start"
+          // height="100%"
+          // alignItems="center"
           onClick={() => {
             if (header.headerLeftAction) {
               header.headerLeftAction();
@@ -86,18 +90,19 @@ function HeaderBar() {
         <Box
           textAlign="center"
           fontSize="16px"
-          fontWeight={500}
-          lineHeight={1.5}
+          fontWeight="500"
+          lineHeight="45px"
         >
           {header?.title ?? ''}
         </Box>
-        <FlexBox textAlign="end" justifyContent="end" flex="0 0 auto">
+        <FlexBox position="absolute" top="6px" right="10px">
           <Box
             aria-label="오른쪽 버튼"
             role="button"
-            marginTop="5px"
-            justifyContent="flex-end"
-            height="100%"
+            // marginTop="5px"
+            // justifyContent="flex-end"
+            width="30px"
+            height="30px"
             alignItems="center"
             onClick={header.headerRightAction}
           >
@@ -105,14 +110,17 @@ function HeaderBar() {
           </Box>
           {header.headerEnd ? (
             <Box
-              marginLeft="15px"
+              // marginLeft="15px"
               aria-label="끝 버튼"
               role="button"
-              paddingLeft="5px"
-              marginTop="5px"
-              justifyContent="flex-end"
-              height="100%"
-              alignItems="center"
+              // paddingLeft="5px"
+              // marginTop="5px"
+              // justifyContent="flex-end"
+              // height="100%"
+              // alignItems="center"
+              marginLeft="8px"
+              width="30px"
+              height="30px"
               onClick={() => {
                 router.push('/');
               }}
@@ -121,7 +129,7 @@ function HeaderBar() {
             </Box>
           ) : null}
         </FlexBox>
-      </FlexBox>
+      </Box>
       <Box height={height} />
     </>
   );

--- a/components/Organisms/Detail/Description.tsx
+++ b/components/Organisms/Detail/Description.tsx
@@ -21,8 +21,15 @@ export default function Description() {
           <BottomSheetHeader />
           <Box backgroundColor={theme.colors.white} padding="0 15px 60px">
             <Tag border={`1px solid ${theme.colors.black}`}>{summary.type}</Tag>
-            <Box marginTop="19px">{summary.title}</Box>
-            <Box marginTop="30px" marginBottom="40px">
+            <Box
+              marginTop="14px"
+              fontSize="19px"
+              fontWeight="500"
+              lineHeight="26px"
+            >
+              {summary.title}
+            </Box>
+            <Box marginTop="30px" marginBottom="60px">
               <DescriptionInfo title="기간" description={summary.term} />
               <DescriptionInfo title="장소" description={summary.place} />
               <DescriptionInfo title="입장료" description={summary.feeType} />

--- a/components/Organisms/Detail/Description/Archive.tsx
+++ b/components/Organisms/Detail/Description/Archive.tsx
@@ -15,7 +15,7 @@ export default function Archive({ data }: ArchiveProps) {
     return <Box> 아카이브 없다</Box>;
   }
   return (
-    <Box color={theme.colors.black} fontSize="14px" padding="0 15px">
+    <Box color={theme.colors.black} fontSize="14px">
       {data.map((item, index) => (
         <Box key={index} paddingTop="24px">
           <FlexBox alignItems="center">
@@ -40,36 +40,27 @@ export default function Archive({ data }: ArchiveProps) {
             </Box>
             <Box flex="0 0 50px " height="20px">
               <Tag
-                display="inline-block"
-                padding="0px !important"
-                marginRight="0px !important"
-                width="100%"
-                textAlign="center"
-                fontSize="13px !important"
-                lineHeight="20px"
+                display="flex !important"
+                alignItems="center"
+                padding="0px 10px !important"
+                margin="0px !important"
                 color={theme.colors.lime}
                 background={theme.colors.black}
                 boxShadow="0 0 8px 0 rgba(0, 0, 0, 0.08)"
               >
-                <Span
-                  display="inline-block"
-                  marginRight="3px"
-                  lineHeight="0"
-                  verticalAlign="text-top"
-                >
-                  <NavWish
-                    fill={theme.colors.lime}
-                    width="15px"
-                    height="20px"
-                  />
-                </Span>
-                25
+                <NavWish
+                  fill={theme.colors.lime}
+                  width="13px"
+                  height="12px"
+                  viewBox="3 4 23 22"
+                />
+                <Span marginLeft="4px">25</Span>
               </Tag>
             </Box>
           </FlexBox>
           <Box
             fontSize="13px"
-            lineHeight="1.54"
+            lineHeight="20px"
             textAlign="left"
             marginTop="20px"
           >

--- a/components/Organisms/Detail/Description/Introduce.tsx
+++ b/components/Organisms/Detail/Description/Introduce.tsx
@@ -15,7 +15,7 @@ export default function Introduce({ data }: IntroduceProps) {
     <Box
       color={theme.colors.black}
       fontSize="13px"
-      lineHeight="1.54"
+      lineHeight="20px"
       textAlign="left"
       padding="40px 0px"
     >
@@ -64,7 +64,7 @@ export default function Introduce({ data }: IntroduceProps) {
           </Button>
         )} */}
       {data.photo?.map((item, index) => (
-        <Box paddingTop="20px" key={index}>
+        <Box marginTop="20px" key={index}>
           <Image
             src={
               !item
@@ -72,9 +72,13 @@ export default function Introduce({ data }: IntroduceProps) {
                 : item
             }
             alt="image"
-            width="345vmin"
-            height="400vmin"
-            objectFit="none"
+            // width="345vmin"
+            // height="400vmin"
+            // objectFit="none"
+            width="100%"
+            height="100%"
+            layout="responsive"
+            // objectFit="none"
           />
         </Box>
       ))}

--- a/components/Organisms/Detail/Navigator.tsx
+++ b/components/Organisms/Detail/Navigator.tsx
@@ -72,6 +72,7 @@ export default function Navigator() {
           아카이브 기록하기
         </Button>
       </FlexBox>
+      <Box width="100%" height="var(--platformBottomArea)" />
     </Box>
   );
 }

--- a/components/Organisms/List/ListItem/ItemAdditionalInfo.tsx
+++ b/components/Organisms/List/ListItem/ItemAdditionalInfo.tsx
@@ -10,25 +10,45 @@ export default function ItemAdditionalInfo(props: AdditionalInfoProps) {
   const listItemAdditionalInfo = props.listItemAdditionalInfo;
   return (
     <>
-      <FlexBox>
+      <FlexBox marginTop="15px">
         {listItemAdditionalInfo.heartCount ? (
-          <Box fontSize="9px" lineHeight="12px">
-            <ListWish width="10" height="9" fill={theme.colors.gray99} />
-            <Span display="inline-block" marginLeft="2px" verticalAlign="top">
+          <FlexBox alignItems="center" marginRight="10px" height="12px">
+            <ListWish
+              width="10px"
+              height="9px"
+              viewBox="0 0 10 9"
+              fill={theme.colors.gray99}
+            />
+            <Box
+              marginLeft="2px"
+              color={theme.colors.gray99}
+              fontSize="9px"
+              lineHeight="12px"
+            >
               {listItemAdditionalInfo.heartCount}
-            </Span>
-          </Box>
+            </Box>
+          </FlexBox>
         ) : (
           ''
         )}
         {listItemAdditionalInfo.grade ? (
-          <Box marginLeft="10px" fontSize="9px" lineHeight="12px">
-            <StarRating width="10" height="10" fill="#999" />
-            <Span display="inline-block" marginLeft="2px" verticalAlign="top">
+          <FlexBox marginRight="10px" height="12px">
+            <StarRating
+              width="10px"
+              height="10px"
+              viewBox="0 0 10 10"
+              fill={theme.colors.gray99}
+            />
+            <Box
+              marginLeft="2px"
+              color={theme.colors.gray99}
+              fontSize="9px"
+              lineHeight="12px"
+            >
               {listItemAdditionalInfo.grade} (
               {listItemAdditionalInfo.archiveCount})
-            </Span>
-          </Box>
+            </Box>
+          </FlexBox>
         ) : (
           ''
         )}

--- a/components/Organisms/List/ListItem/ItemHeart.tsx
+++ b/components/Organisms/List/ListItem/ItemHeart.tsx
@@ -52,10 +52,17 @@ export default function ItemHeart(props: HeartProps) {
   };
 
   return (
-    <Button position="absolute" right="0px" onClick={setToPick}>
+    <Button
+      position="absolute"
+      right="-3px"
+      width="20px"
+      height="20px"
+      onClick={setToPick}
+    >
       <NavWish
-        width="17"
-        height="16"
+        width="17px"
+        height="20px"
+        viewBox="1 2 27 26"
         fill={heart.heartClicked ? theme.colors.black : theme.colors.white}
       />
     </Button>

--- a/components/Organisms/List/ListItem/ItemInfo.tsx
+++ b/components/Organisms/List/ListItem/ItemInfo.tsx
@@ -24,6 +24,7 @@ export default function ItemInfo(props: InfoProps) {
         </Tag>
         {additionalBadgeList.map((badge, index) => (
           <Tag
+            lineHeight="20px"
             backgroundColor={theme.colors.grayEE}
             color={theme.colors.black}
             key={index}
@@ -33,7 +34,6 @@ export default function ItemInfo(props: InfoProps) {
         ))}
       </Box>
       <Box
-        margin="0px 0px 15px"
         fontSize="15px"
         lineHeight="18px"
         fontWeight="500"

--- a/components/Organisms/List/ListOptionFilter.tsx
+++ b/components/Organisms/List/ListOptionFilter.tsx
@@ -57,8 +57,8 @@ export default function ListOptionFilter() {
       }}
     >
       상세필터
-      <Box position="absolute" top="0" right="20px">
-        <Filter />
+      <Box position="absolute" top="0" right="20px" width="14px" height="38px">
+        <Filter width="100%" height="100%" />
       </Box>
     </Button>
   );

--- a/components/Organisms/List/ListSortFilter.tsx
+++ b/components/Organisms/List/ListSortFilter.tsx
@@ -43,8 +43,8 @@ export default function ListSortFilter() {
       }}
     >
       {getSortText}
-      <Box position="absolute" top="0" right="20px">
-        <ArrowDown />
+      <Box position="absolute" top="0" right="20px" width="12px" height="38px">
+        <ArrowDown width="100%" height="100%" />
       </Box>
     </Button>
   );

--- a/components/Organisms/Modal/Filter.tsx
+++ b/components/Organisms/Modal/Filter.tsx
@@ -65,8 +65,8 @@ export default function SelectModal({ payload }: { payload: FilterProps }) {
         ))}
         <FlexBox margin="0px -2.5px">
           <Button
-            flexGrow="0.5"
             margin="0px 2.5px"
+            width="50%"
             fontSize="16px"
             lineHeight="50px"
             fontWeight="500"
@@ -82,8 +82,8 @@ export default function SelectModal({ payload }: { payload: FilterProps }) {
             초기화
           </Button>
           <Button
-            flexGrow="0.5"
             margin="0px 2.5px"
+            width="50%"
             color={theme.colors.white}
             fontSize="16px"
             lineHeight="50px"

--- a/components/Organisms/Modal/Filter.tsx
+++ b/components/Organisms/Modal/Filter.tsx
@@ -65,7 +65,7 @@ export default function SelectModal({ payload }: { payload: FilterProps }) {
         ))}
         <FlexBox margin="0px -2.5px">
           <Button
-            width="170px"
+            flexGrow="0.5"
             margin="0px 2.5px"
             fontSize="16px"
             lineHeight="50px"
@@ -82,7 +82,7 @@ export default function SelectModal({ payload }: { payload: FilterProps }) {
             초기화
           </Button>
           <Button
-            width="170px"
+            flexGrow="0.5"
             margin="0px 2.5px"
             color={theme.colors.white}
             fontSize="16px"

--- a/components/Organisms/MyPage/Archive/ListSection.tsx
+++ b/components/Organisms/MyPage/Archive/ListSection.tsx
@@ -17,7 +17,7 @@ export default function ListSection() {
 
       return (
         <>
-          <Box>
+          <Box marginBottom="60px">
             {data.contents.contents.map((content, index) => (
               <ListCard key={content?.id ?? index} content={content} />
             ))}

--- a/components/Organisms/MyPage/Home/MyPageUserInfo.tsx
+++ b/components/Organisms/MyPage/Home/MyPageUserInfo.tsx
@@ -56,6 +56,7 @@ export default function MyPageUserInfo() {
             height="22px"
             textAlign="center"
             color={theme.colors.white}
+            lineHeight="22px"
             borderRadius="50%"
           >
             +

--- a/components/Organisms/MyPage/LoginPage.tsx
+++ b/components/Organisms/MyPage/LoginPage.tsx
@@ -37,8 +37,6 @@ export default function LoginPage() {
       </Box>
       <Box>
         <Box
-          paddingLeft="100px"
-          paddingRight="99px"
           fontSize="15px"
           fontWeight={500}
           lineHeight={1.47}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -24,10 +24,10 @@ const Home: NextPage = () => {
         </Box>
         <hr />
         <Box>fontWeight Test</Box>
-        <Box fontWeight={800}>800</Box>
-        <Box fontWeight={500}>500</Box>
-        <Box fontWeight={400}>400</Box>
-        <Box fontWeight={200}>200</Box>
+        <Box fontWeight={700}>bold - 700</Box>
+        <Box fontWeight={500}>medium - 500</Box>
+        <Box fontWeight={400}>normal - 400</Box>
+        <Box fontWeight={200}>light - 300</Box>
       </Layout>
     </>
   );

--- a/styles/GlobalStyles.tsx
+++ b/styles/GlobalStyles.tsx
@@ -13,15 +13,44 @@ export default function GlobalStyles() {
     <Global
       styles={css`
         body {
-          font-family: -apple-system, SpoqaHanSansNeo, sans-serif;
+          font-family: -apple-system, SpoqaHanSansNeo, sans-serif !important;
+        }
+        div,
+        input,
+        textarea,
+        button,
+        select,
+        a {
+          font-family: -apple-system, SpoqaHanSansNeo, sans-serif !important;
         }
         @font-face {
           font-family: 'SpoqaHanSansNeo';
-          src: url('/fonts/SpoqaHanSansNeo-Light.ttf') format('ttf'),
-            url('/fonts/SpoqaHanSansNeo-Medium.ttf') format('ttf'),
-            url('/fonts/SpoqaHanSansNeo-Bold.ttf') format('ttf'),
-            url('/fonts/SpoqaHanSansNeo-Regular.ttf') format('ttf'),
-            url('/fonts/SpoqaHanSansNeo-Thin.ttf') format('ttf');
+          font-weight: 700;
+          src: url('../fonts/SpoqaHanSansNeo-Bold.ttf') format('truetype');
+        }
+
+        @font-face {
+          font-family: 'SpoqaHanSansNeo';
+          font-weight: 500;
+          src: url('../fonts/SpoqaHanSansNeo-Medium.ttf') format('truetype');
+        }
+
+        @font-face {
+          font-family: 'SpoqaHanSansNeo';
+          font-weight: 400;
+          src: url('../fonts/SpoqaHanSansNeo-Regular.ttf') format('truetype');
+        }
+
+        @font-face {
+          font-family: 'SpoqaHanSansNeo';
+          font-weight: 300;
+          src: url('../fonts/SpoqaHanSansNeo-Light.ttf') format('truetype');
+        }
+
+        @font-face {
+          font-family: 'SpoqaHanSansNeo';
+          font-weight: 100;
+          src: url('../fonts/SpoqaHanSansNeo-Thin.ttf') format('truetype');
         }
 
         :root {


### PR DESCRIPTION
## **📄 PR 카테고리**

- ⬜️ 리팩토링
- ✅ 화면 개발 ( 추가, 수정, 삭제 )
- ⬜️ QA 및 버그 수정
- ⬜️ 기타 ( 버전 업데이트 등 )

## **⌨️ 변경점**
전반적으로 css를 수정하였습니다.
1. 폰트 적용
- fontWeight = "폰트 두께 관련 숫자"

<img width="176" alt="스크린샷 2022-07-15 오후 11 45 05" src="https://user-images.githubusercontent.com/38105502/179247276-569920df-00d6-495a-aea0-3aba874fdd5e.png">

2. 마이페이지 > 회원정보 수정 > 헤더 깨짐 수정
- flex로 되어있는걸 absolute로 수정하였습니다.

<img width="387" alt="스크린샷 2022-07-15 오후 11 44 28" src="https://user-images.githubusercontent.com/38105502/179247174-d46bd685-7767-46ca-93a7-f349ccb2eeef.png">

3. 마이아카이브 가려지는 현상 수정
4. 상품상세 아카이브 작성 하단 nav safe-area추가

## **🤦🏻 고민한 부분**

## **🙋🏼‍♀️ 추가 논의가 필요한 부분**

## **✋ 추가 코멘트**
먼저 보이는 부분을 기준으로 하나씩 수정하고 있습니다.
리스트 > 상세 > 마이페이지 순으로 작업중입니다.