### PR TITLE
Feat: modal 생성시 바닥페이지 스크롤 제어

### DIFF
--- a/components/Organisms/Common/Container.tsx
+++ b/components/Organisms/Common/Container.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+import { useRecoilValue } from 'recoil';
 
 import NavHome from 'assets/common/bottomTabNavigator/NavHome';
 import NavList from 'assets/common/bottomTabNavigator/NavList';
@@ -7,11 +8,17 @@ import NavWish from 'assets/common/bottomTabNavigator/NavWish';
 import { Box } from 'components/Atoms';
 import BottomTabNavigator from 'components/Organisms/Common/BottomTabNavigator';
 import HeaderBar from 'components/Organisms/Common/HeaderBar';
+import { modalOutState } from 'states/modal';
 import theme from 'styles/theme';
 
 export default function Container({ children }: { children: ReactNode }) {
+  const modalOut = useRecoilValue(modalOutState);
   return (
-    <>
+    <Box
+      style={
+        modalOut ? { position: 'fixed', inset: '0', touchAction: 'none' } : {}
+      }
+    >
       <HeaderBar />
       <Box>{children}</Box>
       <BottomTabNavigator
@@ -43,6 +50,6 @@ export default function Container({ children }: { children: ReactNode }) {
           },
         ]}
       />
-    </>
+    </Box>
   );
 }

--- a/components/Organisms/Modal/ModalContainer.tsx
+++ b/components/Organisms/Modal/ModalContainer.tsx
@@ -1,11 +1,18 @@
-import { useRecoilValue } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import ModalBox from 'components/Organisms/Modal/ModalBox';
 import { ModalComponents } from 'constants/type/initialModal';
-import { modalState } from 'states/modal';
+import { modalOutState, modalState } from 'states/modal';
 
 export default function ModalContainer() {
   const modals = useRecoilValue(modalState);
+  const setModalOutState = useSetRecoilState(modalOutState);
+
+  if (modals.length !== 0) {
+    setModalOutState(true);
+  } else {
+    setModalOutState(false);
+  }
 
   return (
     <>

--- a/states/modal.ts
+++ b/states/modal.ts
@@ -6,3 +6,8 @@ export const modalState = atom<ModalProps[]>({
   key: 'modalState',
   default: [],
 });
+
+export const modalOutState = atom<boolean>({
+  key: 'modalOutState',
+  default: false,
+});


### PR DESCRIPTION
## **📄 PR 카테고리**

- ⬜️ 리팩토링
- ✅ 화면 개발 ( 추가, 수정, 삭제 )
- ⬜️ QA 및 버그 수정
- ⬜️ 기타 ( 버전 업데이트 등 )

## **⌨️ 변경점**
modal 호출 시 바닥페이지 스크롤 제어

## **🤦🏻 고민한 부분**
1. <body> 태그에 'overflow:hidden, touch-action:none'으로 스크롤을 제어하려고 했지만, body태그의 직접 접근 대신 바닥페이지의position을 fixed로 변경하여 스크롤 제어
  
## **🙋🏼‍♀️ 추가 논의가 필요한 부분**

## **✋ 추가 코멘트**
