### PR TITLE
Refactor: 로그인 alert 확인/취소 버튼 변경 및 공통 alert 수정

### DIFF
--- a/components/Atoms/Shadow.tsx
+++ b/components/Atoms/Shadow.tsx
@@ -12,6 +12,6 @@ export default styled.div<PopupProps>`
   width: 100%;
   height: 100vh;
   left: 0;
-  background-color: rgb(0, 0, 0, 0.8);
+  background-color: rgb(0, 0, 0, 0.7);
   z-index: ${Z_INDEX.LOADING};
 `;

--- a/components/Organisms/Archive/ArchiveHome.tsx
+++ b/components/Organisms/Archive/ArchiveHome.tsx
@@ -74,7 +74,6 @@ export default function ArchiveHome() {
 
   return (
     <>
-      <PopupRouter />
       <Box>{title ? null : <SearchTitle />}</Box>
       <form onSubmit={handleSubmit(onSubmit)}>
         <Box>

--- a/components/Organisms/MyPage/MyPageHome.tsx
+++ b/components/Organisms/MyPage/MyPageHome.tsx
@@ -12,7 +12,6 @@ export default function MyPageHome() {
   ];
   return (
     <Box paddingLeft="15px" paddingRight="15px">
-      <PopupRouter />
       <MyPageUserInfo />
       {/* 앵커 */}
       <TopTabView data={data} minusHeight={200}></TopTabView>

--- a/components/Organisms/Popup/AlertLoginConfirmationPopup.tsx
+++ b/components/Organisms/Popup/AlertLoginConfirmationPopup.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { useRouter } from 'next/router';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import { Box, Button } from 'components/Atoms';
@@ -10,8 +11,14 @@ import theme from 'styles/theme';
 const AlertLoginConfirmationPopup = () => {
   const alertState = useRecoilValue(AlertState);
   const setPopupName = useSetRecoilState(PopupNameState);
+  const router = useRouter();
 
-  const handleClosePopup = () => {
+  const handleConfirm = () => {
+    setPopupName(POPUP_NAME.NULL);
+    router.push('/mypage');
+  };
+
+  const handleCancel = () => {
     setPopupName(POPUP_NAME.NULL);
   };
 
@@ -38,11 +45,21 @@ const AlertLoginConfirmationPopup = () => {
         </Box>
         <Button
           height="50px"
-          width="100%"
+          width="50%"
           fontSize="16px"
-          borderRadius="0 0 12px 12px"
+          borderRadius="0 0 0 12px"
+          backgroundColor={theme.colors.grayEE}
+          onClick={handleCancel}
+        >
+          <Box color={theme.colors.black}>취소</Box>
+        </Button>
+        <Button
+          height="50px"
+          width="50%"
+          fontSize="16px"
+          borderRadius="0 0 12px 0"
           backgroundColor={theme.colors.black}
-          onClick={handleClosePopup}
+          onClick={handleConfirm}
         >
           <Box color={theme.colors.white}>확인</Box>
         </Button>


### PR DESCRIPTION
## **📄 PR 카테고리**

- ✅ 리팩토링
- ⬜️ 화면 개발 ( 추가, 수정, 삭제 )
- ⬜️ QA 및 버그 수정
- ⬜️ 기타 ( 버전 업데이트 등 )

## **⌨️ 변경점**
1. 로그인 alert 확인 버튼 -> 취소/확인 버튼 
취소 > 리스트페이지 유지 || 확인 > 마이페이지 이동

<img width="341" alt="스크린샷 2022-08-09 오후 5 21 44" src="https://user-images.githubusercontent.com/38105502/183600790-fdaa4a3a-8e79-494e-a103-ab6b5b4787f4.png">

2. alert dim 투명도 80 > 70 변경

3.  개별페이지에 선언된 <PopupRouter /> 삭제 
 - app.txs에서 공통 선언
<img width="848" alt="스크린샷 2022-08-09 오후 5 23 33" src="https://user-images.githubusercontent.com/38105502/183601146-8ddc7474-8674-4902-abb3-93cd72286476.png">

## **🤦🏻 고민한 부분**

## **🙋🏼‍♀️ 추가 논의가 필요한 부분**

## **✋ 추가 코멘트**
