### PR TITLE
픽 페이지 목업 수정

### DIFF
--- a/components/Organisms/Common/Container.tsx
+++ b/components/Organisms/Common/Container.tsx
@@ -45,7 +45,7 @@ export default function Container({ children }: { children: ReactNode }) {
             selectedIcon: <NavWish fill={theme.colors.black} />,
             icon: <NavWish />,
             pathName: 'PICK',
-            path: ['/wish'],
+            path: ['/pick'],
           },
           {
             selectedIcon: <NavMyPage fill={theme.colors.black} />,

--- a/components/Organisms/Pick/MyPickPage.tsx
+++ b/components/Organisms/Pick/MyPickPage.tsx
@@ -1,0 +1,18 @@
+import { FlexBox } from 'components/Atoms';
+import PickSection from 'components/Organisms/Pick/PickSection';
+import PickTitle from 'components/Organisms/Pick/PickTitle';
+
+export default function MyPickPage() {
+  return (
+    <>
+      <PickTitle />
+      <FlexBox
+        padding="0px 12.5px !important"
+        flexWrap="wrap"
+        marginBottom="120px"
+      >
+        <PickSection />
+      </FlexBox>
+    </>
+  );
+}

--- a/components/Organisms/Pick/NoPickList.tsx
+++ b/components/Organisms/Pick/NoPickList.tsx
@@ -1,0 +1,27 @@
+import Alert from 'assets/error/Alert';
+import { Box } from 'components/Atoms';
+
+export default function NoPickList() {
+  return (
+    <Box
+      position="fixed"
+      top="calc(50% - 110px)"
+      left="0px"
+      width="100%"
+      textAlign="center"
+      fontSize="0"
+    >
+      <Alert width="40px" height="40px" />
+      <Box
+        margin="20px 0px 12px"
+        fontSize="13px"
+        lineHeight="20px"
+        fontWeight="500"
+      >
+        PICK한 문화생활이 없습니다.
+        <br />
+        관심있는 문화생활에 하트를 눌러주세요.
+      </Box>
+    </Box>
+  );
+}

--- a/components/Organisms/Pick/PickCard.tsx
+++ b/components/Organisms/Pick/PickCard.tsx
@@ -41,6 +41,7 @@ export default function PickItem({ content }: ItemProps) {
       flex="0 0 50%"
       padding="0px 2.5px"
       css={css`
+        // 픽 리스트가 3개 이상일 경우 3번째 리스트 부터 margin-top(40)
         &:nth-child(n + 3) {
           margin-top: 40px;
         }

--- a/components/Organisms/Pick/PickCard.tsx
+++ b/components/Organisms/Pick/PickCard.tsx
@@ -1,0 +1,57 @@
+import { css } from '@emotion/react';
+
+import { Box } from 'components/Atoms';
+import PickHeart from 'components/Organisms/Pick/PickItem/PickHeart';
+import PickItemImage from 'components/Organisms/Pick/PickItem/PickItemImage';
+import PickItemInfo from 'components/Organisms/Pick/PickItem/PickItemInfo';
+
+interface ItemProps {
+  content: PickPageContent;
+}
+
+interface PickPageContent {
+  additionalBadgeList: {
+    text: string;
+    typeBadge: boolean;
+  }[];
+  heart: {
+    heartClicked: boolean;
+    id: number;
+    link: string;
+  };
+  id: number;
+  presentationImage: {
+    url: string;
+    link: string;
+    backgroundText: string;
+    dimColor: string;
+    opacity: number;
+    dimTarget: boolean;
+  };
+  title: {
+    link: string;
+    text: string;
+  };
+}
+
+export default function PickItem({ content }: ItemProps) {
+  return (
+    <Box
+      position="relative"
+      flex="0 0 50%"
+      padding="0px 2.5px"
+      css={css`
+        &:nth-child(n + 3) {
+          margin-top: 40px;
+        }
+      `}
+    >
+      <PickHeart />
+      <PickItemImage presentationImage={content.presentationImage} />
+      <PickItemInfo
+        title={content.title}
+        additionalBadgeList={content.additionalBadgeList}
+      />
+    </Box>
+  );
+}

--- a/components/Organisms/Pick/PickItem/PickHeart.tsx
+++ b/components/Organisms/Pick/PickItem/PickHeart.tsx
@@ -1,0 +1,29 @@
+import ListWish from 'assets/list/ListWish';
+import { Box } from 'components/Atoms';
+import theme from 'styles/theme';
+
+export default function ItemHeart() {
+  const pickClick = () => {
+    console.log('click');
+  };
+
+  return (
+    <>
+      <Box
+        position="absolute"
+        top="5px"
+        right="7.5px"
+        height="32px"
+        width="32px"
+        background="rgba(0,0,0,0.6)"
+        borderRadius="16px"
+        zIndex="2"
+        onClick={() => pickClick()}
+      >
+        <Box position="absolute" top="calc(50% - 7.5px)" left="calc(50% - 8px)">
+          <ListWish width="16px" height="15px" fill={theme.colors.lime} />
+        </Box>
+      </Box>
+    </>
+  );
+}

--- a/components/Organisms/Pick/PickItem/PickHeart.tsx
+++ b/components/Organisms/Pick/PickItem/PickHeart.tsx
@@ -2,7 +2,7 @@ import ListWish from 'assets/list/ListWish';
 import { Box } from 'components/Atoms';
 import theme from 'styles/theme';
 
-export default function ItemHeart() {
+export default function PickHeart() {
   const pickClick = () => {
     console.log('click');
   };

--- a/components/Organisms/Pick/PickItem/PickItemImage.tsx
+++ b/components/Organisms/Pick/PickItem/PickItemImage.tsx
@@ -1,0 +1,71 @@
+import { css } from '@emotion/react';
+import Image from 'next/image';
+import { useRouter } from 'next/router';
+
+import noImage from 'assets/common/no_image_375x250.png';
+import { Box } from 'components/Atoms';
+import theme from 'styles/theme';
+
+interface ImagePorps {
+  presentationImage: {
+    url: string;
+    link: string;
+    backgroundText: string;
+    dimColor: string;
+    opacity: number;
+    dimTarget: boolean;
+  };
+}
+
+export default function PickItemImage({ presentationImage }: ImagePorps) {
+  const router = useRouter();
+  return (
+    <>
+      <Box
+        position="relative"
+        css={css`
+          cursor: pointer;
+        `}
+        onClick={() => {
+          router.push(presentationImage.link);
+        }}
+      >
+        {presentationImage.dimTarget ? (
+          <>
+            <Box
+              position="absolute"
+              top="0px"
+              bottom="0px"
+              left="0px"
+              right="0px"
+              backgroundColor={presentationImage.dimColor}
+              opacity={presentationImage.opacity}
+              zIndex="1"
+            />
+            <Box
+              position="absolute"
+              top="calc(50% - 16px)"
+              left="calc(50% - 30px)"
+              color={theme.colors.white}
+              fontSize="26px"
+              lineHeight="32px"
+              zIndex="2"
+            >
+              {presentationImage.backgroundText}
+            </Box>
+          </>
+        ) : (
+          ''
+        )}
+        <Image
+          src={!presentationImage.url ? noImage : presentationImage.url}
+          alt="image"
+          width="170"
+          height="228"
+          layout="responsive"
+          objectFit="cover"
+        />
+      </Box>
+    </>
+  );
+}

--- a/components/Organisms/Pick/PickItem/PickItemInfo.tsx
+++ b/components/Organisms/Pick/PickItem/PickItemInfo.tsx
@@ -1,0 +1,38 @@
+import { Box, Tag } from 'components/Atoms';
+import theme from 'styles/theme';
+
+interface InfoPorps {
+  title: {
+    link: string;
+    text: string;
+  };
+  additionalBadgeList: {
+    text: string;
+    typeBadge: boolean;
+  }[];
+}
+
+export default function PickItemInfo({
+  title,
+  additionalBadgeList,
+}: InfoPorps) {
+  return (
+    <Box position="relative" marginTop="10px">
+      <Box position="absolute" bottom="35px" left="5px" zIndex="1">
+        {additionalBadgeList.map((badge, index) => (
+          <Tag
+            padding="0px 10px !important"
+            fontSize="10px !important"
+            background={theme.colors.grayEE}
+            key={index}
+          >
+            {badge.text}
+          </Tag>
+        ))}
+      </Box>
+      <Box fontSize="13px" fontWeight="500" lineHeight="18px">
+        {title.text}
+      </Box>
+    </Box>
+  );
+}

--- a/components/Organisms/Pick/PickLogin.tsx
+++ b/components/Organisms/Pick/PickLogin.tsx
@@ -1,0 +1,52 @@
+import { useRouter } from 'next/router';
+
+import Alert from 'assets/error/Alert';
+import { Box, Button } from 'components/Atoms';
+
+export default function PickLogin() {
+  const router = useRouter();
+  return (
+    <>
+      <Box
+        padding="0px 15px 30px 15px"
+        fontSize="22px"
+        lineHeight="27px"
+        fontWeight="500"
+      >
+        PCIK
+      </Box>
+      <Box
+        position="fixed"
+        top="calc(50% - 110px)"
+        left="0px"
+        width="100%"
+        textAlign="center"
+        fontSize="0"
+      >
+        <Alert width="40px" height="40px" />
+        <Box
+          margin="20px 0px 12px"
+          fontSize="13px"
+          lineHeight="20px"
+          fontWeight="500"
+        >
+          로그인 후 이용해주세요.
+        </Box>
+        <Button
+          display="inline-block"
+          height="40px"
+          width="130px"
+          color="#ffffff"
+          fontSize="13px"
+          lineHeight="40px"
+          background="#000000"
+          onClick={() => {
+            router.push('/mypage');
+          }}
+        >
+          로그인 하기
+        </Button>
+      </Box>
+    </>
+  );
+}

--- a/components/Organisms/Pick/PickLogin.tsx
+++ b/components/Organisms/Pick/PickLogin.tsx
@@ -2,6 +2,7 @@ import { useRouter } from 'next/router';
 
 import Alert from 'assets/error/Alert';
 import { Box, Button } from 'components/Atoms';
+import theme from 'styles/theme';
 
 export default function PickLogin() {
   const router = useRouter();
@@ -13,7 +14,7 @@ export default function PickLogin() {
         lineHeight="27px"
         fontWeight="500"
       >
-        PCIK
+        PICK
       </Box>
       <Box
         position="fixed"
@@ -36,10 +37,10 @@ export default function PickLogin() {
           display="inline-block"
           height="40px"
           width="130px"
-          color="#ffffff"
+          color={theme.colors.white}
           fontSize="13px"
           lineHeight="40px"
-          background="#000000"
+          background={theme.colors.black}
           onClick={() => {
             router.push('/mypage');
           }}

--- a/components/Organisms/Pick/PickSection.tsx
+++ b/components/Organisms/Pick/PickSection.tsx
@@ -1,0 +1,16 @@
+import { useRecoilValue } from 'recoil';
+
+import PickItem from 'components/Organisms/Pick/PickCard';
+import { PickState } from 'states';
+
+export default function PickSection() {
+  const data = useRecoilValue(PickState);
+
+  return (
+    <>
+      {data.contents.map((content, index) => (
+        <PickItem key={content.id ?? index} content={content}></PickItem>
+      ))}
+    </>
+  );
+}

--- a/components/Organisms/Pick/PickTitle.tsx
+++ b/components/Organisms/Pick/PickTitle.tsx
@@ -1,0 +1,29 @@
+import { useRecoilValue } from 'recoil';
+
+import { Box, Span } from 'components/Atoms';
+import { PickState } from 'states';
+import theme from 'styles/theme';
+
+export default function PickTitle() {
+  const pickCount = useRecoilValue(PickState);
+
+  return (
+    <>
+      <Box
+        padding="0px 15px 30px 15px"
+        fontSize="22px"
+        lineHeight="27px"
+        fontWeight="500"
+      >
+        <Span
+          display="inline-block"
+          marginRight="3px"
+          color={theme.colors.orange}
+        >
+          {pickCount.count}
+        </Span>
+        PCIK
+      </Box>
+    </>
+  );
+}

--- a/components/Organisms/Pick/PickTitle.tsx
+++ b/components/Organisms/Pick/PickTitle.tsx
@@ -22,7 +22,7 @@ export default function PickTitle() {
         >
           {pickCount.count}
         </Span>
-        PCIK
+        PICK
       </Box>
     </>
   );

--- a/components/Organisms/Pick/data.ts
+++ b/components/Organisms/Pick/data.ts
@@ -1,0 +1,155 @@
+export const data = {
+  contents: [
+    {
+      additionalBadgeList: [
+        {
+          text: '전시회',
+          typeBadge: false,
+        },
+        {
+          text: 'on',
+          typeBadge: false,
+        },
+      ],
+      heart: {
+        heartClicked: true,
+        id: 0,
+        link: 'string',
+      },
+      id: 0,
+      presentationImage: {
+        backgroundText: '종료',
+        dimColor: '#000',
+        dimTarget: true,
+        link: '/detail/655',
+        opacity: 0.55,
+        url: 'https://kilometer-image.s3.ap-northeast-2.amazonaws.com/static/bo/2022-07-10/063807-163c1b616f2a4f11815aeac11418fee9_20220124174205.jpg',
+      },
+      title: {
+        link: '/detail/65',
+        text: '아르떼 뮤지엄 제주',
+      },
+    },
+    {
+      additionalBadgeList: [
+        {
+          text: '전시회',
+          typeBadge: false,
+        },
+        {
+          text: 'on',
+          typeBadge: false,
+        },
+      ],
+      heart: {
+        heartClicked: true,
+        id: 0,
+        link: 'string',
+      },
+      id: 0,
+      presentationImage: {
+        backgroundText: '',
+        dimColor: '',
+        dimTarget: false,
+        link: '/detail/655',
+        opacity: 0,
+        url: 'https://kilometer-image.s3.ap-northeast-2.amazonaws.com/static/bo/2022-07-10/063807-163c1b616f2a4f11815aeac11418fee9_20220124174205.jpg',
+      },
+      title: {
+        link: '/detail/65',
+        text: '아르떼 뮤지엄 제주',
+      },
+    },
+    {
+      additionalBadgeList: [
+        {
+          text: '전시회',
+          typeBadge: false,
+        },
+        {
+          text: 'on',
+          typeBadge: false,
+        },
+      ],
+      heart: {
+        heartClicked: true,
+        id: 0,
+        link: 'string',
+      },
+      id: 0,
+      presentationImage: {
+        backgroundText: '',
+        dimColor: '',
+        dimTarget: false,
+        link: '/detail/655',
+        opacity: 0,
+        url: 'https://kilometer-image.s3.ap-northeast-2.amazonaws.com/static/bo/2022-07-10/063807-163c1b616f2a4f11815aeac11418fee9_20220124174205.jpg',
+      },
+      title: {
+        link: '/detail/65',
+        text: '아르떼 뮤지엄 제주',
+      },
+    },
+    {
+      additionalBadgeList: [
+        {
+          text: '전시회',
+          typeBadge: false,
+        },
+        {
+          text: 'on',
+          typeBadge: false,
+        },
+      ],
+      heart: {
+        heartClicked: true,
+        id: 0,
+        link: 'string',
+      },
+      id: 0,
+      presentationImage: {
+        backgroundText: '',
+        dimColor: '',
+        dimTarget: false,
+        link: '/detail/655',
+        opacity: 0,
+        url: 'https://kilometer-image.s3.ap-northeast-2.amazonaws.com/static/bo/2022-07-10/063807-163c1b616f2a4f11815aeac11418fee9_20220124174205.jpg',
+      },
+      title: {
+        link: '/detail/65',
+        text: '아르떼 뮤지엄 제주',
+      },
+    },
+    {
+      additionalBadgeList: [
+        {
+          text: '전시회',
+          typeBadge: false,
+        },
+        {
+          text: 'on',
+          typeBadge: false,
+        },
+      ],
+      heart: {
+        heartClicked: true,
+        id: 0,
+        link: 'string',
+      },
+      id: 0,
+      presentationImage: {
+        backgroundText: '',
+        dimColor: '',
+        dimTarget: false,
+        link: '/detail/655',
+        opacity: 0,
+        url: 'https://kilometer-image.s3.ap-northeast-2.amazonaws.com/static/bo/2022-07-10/063807-163c1b616f2a4f11815aeac11418fee9_20220124174205.jpg',
+      },
+      title: {
+        link: '/detail/65',
+        text: '아르떼 뮤지엄 제주',
+      },
+    },
+  ],
+  count: 5,
+};

--- a/pages/pick/index.tsx
+++ b/pages/pick/index.tsx
@@ -1,0 +1,24 @@
+import { useRecoilValue } from 'recoil';
+
+import { Box, FlexBox, Layout } from 'components/Atoms';
+import MyPickPage from 'components/Organisms/Pick/MyPickPage';
+import PickLogin from 'components/Organisms/Pick/PickLogin';
+import PickSection from 'components/Organisms/Pick/PickSection';
+import PickTitle from 'components/Organisms/Pick/PickTitle';
+import { User } from 'states/user';
+import { useInitHeader } from 'utils/hooks/useInitHeader';
+
+export default function Pick() {
+  const loginState = useRecoilValue(User);
+
+  useInitHeader({
+    headerRight: 'search',
+    headerLeft: 'disabled',
+  });
+
+  if (loginState.isLogin) {
+    return <MyPickPage />;
+  } else {
+    return <PickLogin />;
+  }
+}

--- a/pages/pick/index.tsx
+++ b/pages/pick/index.tsx
@@ -1,10 +1,7 @@
 import { useRecoilValue } from 'recoil';
 
-import { Box, FlexBox, Layout } from 'components/Atoms';
 import MyPickPage from 'components/Organisms/Pick/MyPickPage';
 import PickLogin from 'components/Organisms/Pick/PickLogin';
-import PickSection from 'components/Organisms/Pick/PickSection';
-import PickTitle from 'components/Organisms/Pick/PickTitle';
 import { User } from 'states/user';
 import { useInitHeader } from 'utils/hooks/useInitHeader';
 

--- a/states/index.ts
+++ b/states/index.ts
@@ -3,6 +3,7 @@ import { ArchiveWirteState } from './archiveWirte';
 import { DetailState } from './detail';
 import ListState from './list';
 import MyArchiveListState from './myArchiveList';
+import PickState from './pick';
 import PopupNameState from './popupName';
 import { searchRequest } from './search-request';
 import TestSate from './test';
@@ -16,4 +17,5 @@ export {
   MyArchiveListState,
   PopupNameState,
   AlertState,
+  PickState,
 };

--- a/states/pick.ts
+++ b/states/pick.ts
@@ -1,0 +1,8 @@
+import { atom } from 'recoil';
+
+import { data } from 'components/Organisms/Pick/data';
+
+export default atom({
+  key: 'PickState',
+  default: data,
+});


### PR DESCRIPTION
## **📄 PR 카테고리**

- ⬜️ 리팩토링
- ✅ 화면 개발 ( 추가, 수정, 삭제 )
- ⬜️ QA 및 버그 수정
- ⬜️ 기타 ( 버전 업데이트 등 )

## **⌨️ 변경점**
1. 하단 네이게이션 이동 위치를 wish -> pick으로 변경하였습니다.
2. 댓글로 요청하신 부분 수정

## **🤦🏻 고민한 부분**
상단 PICK 타이틀을 현재 로그인/미로그인 따로 사용하였는데, 공통으로 뺄까 생각중입니다,,,

## **🙋🏼‍♀️ 추가 논의가 필요한 부분**

## **✋ 추가 코멘트**
