### PR TITLE
상세페이지 관련 에러처리

### DIFF
--- a/assets/common/header/Search.tsx
+++ b/assets/common/header/Search.tsx
@@ -1,8 +1,8 @@
 export default function Search({
-  width = '18',
-  height = '18',
+  width = '19.436',
+  height = '19.312',
   fill = '#000',
-  viewBox = '0 0 18.964 18.964',
+  viewBox = '0 0 19.436 19.312',
 }) {
   return (
     <svg
@@ -11,22 +11,28 @@ export default function Search({
       height={height}
       viewBox={viewBox}
     >
-      <g data-name="*search">
-        <path
-          data-name="패스 421"
-          d="M7.988 1.038A6.95 6.95 0 0 1 12.9 12.9a6.95 6.95 0 0 1-9.826-9.826 6.9 6.9 0 0 1 4.914-2.036m0-1.038a7.988 7.988 0 1 0 5.648 2.34A7.963 7.963 0 0 0 7.988 0"
-          transform="translate(.05 .05)"
-          strokeWidth=".1px"
+      <g data-name="*search" transform="translate(.1 .1)">
+        <circle
+          data-name="타원 233"
+          cx="7.625"
+          cy="7.625"
+          r="7.625"
+          transform="translate(.5 .5)"
+          fill="none"
           stroke={fill}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="1.2px"
         />
         <path
-          data-name="선 1"
-          transform="translate(13.464 13.464)"
+          data-name="선 976"
+          transform="translate(13.561 13.473)"
           fill="none"
-          strokeLinecap="round"
-          strokeMiterlimit="10"
           stroke={fill}
-          d="m0 0 4.793 4.793"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="1.2px"
+          d="M4.927 4.891 0 0"
         />
       </g>
     </svg>

--- a/components/Organisms/Common/HeaderBar.tsx
+++ b/components/Organisms/Common/HeaderBar.tsx
@@ -39,7 +39,7 @@ const headerLeftIcon = {
 };
 
 const headerRightIcon = {
-  search: <Search width="30" height="30" viewBox="-6 -6 30 30" />,
+  search: <Search width="18" height="18" />,
   close: <CloseBtn stroke="#000"></CloseBtn>,
   disabled: <></>,
 };
@@ -116,7 +116,7 @@ function HeaderBar() {
               <FlexBox
                 position="absolute"
                 top={header.headerRight === 'close' ? '10px' : '6px'}
-                right="10px"
+                right="20px"
               >
                 <Box
                   aria-label="오른쪽 버튼"
@@ -124,6 +124,7 @@ function HeaderBar() {
                   width="30px"
                   height="30px"
                   alignItems="center"
+                  padding="6px"
                   onClick={header.headerRightAction}
                 >
                   {headerRightIcon[header.headerRight ?? 'search']}
@@ -134,6 +135,7 @@ function HeaderBar() {
                     role="button"
                     width="30px"
                     height="30px"
+                    paddingLeft="10px"
                     onClick={() => {
                       router.push('/');
                     }}

--- a/components/Organisms/Common/HeaderBar.tsx
+++ b/components/Organisms/Common/HeaderBar.tsx
@@ -135,7 +135,7 @@ function HeaderBar() {
                     role="button"
                     width="30px"
                     height="30px"
-                    paddingLeft="10px"
+                    paddingLeft="6px"
                     onClick={() => {
                       router.push('/');
                     }}

--- a/components/Organisms/Detail/Description.tsx
+++ b/components/Organisms/Detail/Description.tsx
@@ -1,39 +1,20 @@
-import Link from 'next/link';
-import { useRouter } from 'next/router';
 import { createRef, Suspense, useEffect } from 'react';
 import { useRecoilValue } from 'recoil';
 
 import { Box, Button, Span, Tag } from 'components/Atoms';
-import DescriptionInfo from 'components/Molecules/DescriptionInfo';
-import InnerHTML from 'components/Molecules/InnerHTML';
 import Archive from 'components/Organisms/Detail/Description/Archive';
 import BottomSheetHeader from 'components/Organisms/Detail/Description/BottomSheetHeader';
 import { DetailNavigation } from 'components/Organisms/Detail/Description/DetailNavigation';
 import Introduce from 'components/Organisms/Detail/Description/Introduce';
 import Summary from 'components/Organisms/Detail/Description/Summary';
-import {
-  detailArchiveState,
-  detailIntroductionState,
-  detailSummaryState,
-  useResetDetailArchiveFunction,
-} from 'states/detail';
+import { DetailState } from 'states';
 import theme from 'styles/theme';
 
 export default function Description() {
-  const router = useRouter();
-  const { id } = router.query;
   const archiveRef = createRef<HTMLDivElement>();
   const introduceRef = createRef<HTMLDivElement>();
-  const introductionData = useRecoilValue(detailIntroductionState(Number(id)));
-  const archiveData = useRecoilValue(detailArchiveState(Number(id)));
-
-  const tabViewData =
-    introductionData.summary === null && introductionData.photo.length === 0
-      ? [{ ...archiveData }]
-      : [
-          { contents: { ...introductionData }, title: '소개' },
-          { ...archiveData },
-        ];
+  const data = useRecoilValue(DetailState);
+  const { tabViewData } = data;
 
   return (
     <Suspense fallback={<div>Loading...</div>}>

--- a/components/Organisms/Detail/Description.tsx
+++ b/components/Organisms/Detail/Description.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { createRef } from 'react';
-import { useRecoilValueLoadable } from 'recoil';
+import { createRef, Suspense, useEffect } from 'react';
+import { useRecoilValue } from 'recoil';
 
 import { Box, Button, Span, Tag } from 'components/Atoms';
 import DescriptionInfo from 'components/Molecules/DescriptionInfo';
@@ -10,131 +10,67 @@ import Archive from 'components/Organisms/Detail/Description/Archive';
 import BottomSheetHeader from 'components/Organisms/Detail/Description/BottomSheetHeader';
 import { DetailNavigation } from 'components/Organisms/Detail/Description/DetailNavigation';
 import Introduce from 'components/Organisms/Detail/Description/Introduce';
-import { DetailState } from 'states';
+import Summary from 'components/Organisms/Detail/Description/Summary';
+import {
+  detailArchiveState,
+  detailIntroductionState,
+  detailSummaryState,
+  useResetDetailArchiveFunction,
+} from 'states/detail';
 import theme from 'styles/theme';
 
 export default function Description() {
   const router = useRouter();
   const { id } = router.query;
-  const { contents, state } = useRecoilValueLoadable(DetailState(Number(id)));
-  const { summary, tabViewData } = contents;
   const archiveRef = createRef<HTMLDivElement>();
   const introduceRef = createRef<HTMLDivElement>();
+  const introductionData = useRecoilValue(detailIntroductionState(Number(id)));
+  const archiveData = useRecoilValue(detailArchiveState(Number(id)));
 
-  switch (state) {
-    case 'hasValue':
-      return (
-        <Box position="relative" top="390px">
-          <BottomSheetHeader />
-          <Box
-            backgroundColor={theme.colors.white}
-            padding="0 15px 60px"
-            marginTop="-1px"
-          >
-            <Tag border={`1px solid ${theme.colors.black}`}>
-              {summary?.type}
-            </Tag>
-            <Box
-              marginTop="14px"
-              fontSize="19px"
-              fontWeight="500"
-              lineHeight="26px"
-            >
-              {summary?.title}
-            </Box>
-            <Box marginTop="30px" marginBottom="60px">
-              <DescriptionInfo title="기간" description={summary?.term} />
-              <DescriptionInfo title="장소" description={summary?.place} />
-              {summary?.feeType === '유료' ? (
-                <>
-                  <DescriptionInfo
-                    title="입장료"
-                    description={
-                      <Box>
-                        <Box>{summary?.feeType}</Box>
-                        <Box>
-                          {summary?.price ? (
-                            <InnerHTML data={summary?.price} />
-                          ) : null}
-                        </Box>
-                        <Button marginTop="8px">
-                          <Link href={summary?.ticketUrl}>
-                            <a target="_blank" rel="noreferrer">
-                              <Span color={theme.colors.gray99}>
-                                티켓 구매하기
-                                <Span paddingLeft="8px">{'>'}</Span>
-                              </Span>
-                            </a>
-                          </Link>
-                        </Button>
-                      </Box>
-                    }
-                  />
-                </>
+  const tabViewData =
+    introductionData.summary === null && introductionData.photo.length === 0
+      ? [{ ...archiveData }]
+      : [
+          { contents: { ...introductionData }, title: '소개' },
+          { ...archiveData },
+        ];
+
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <Box position="relative" top="390px">
+        <BottomSheetHeader />
+        <Box
+          backgroundColor={theme.colors.white}
+          padding="0 15px 60px"
+          marginTop="-1px"
+        >
+          <Summary />
+          <DetailNavigation
+            deatailMetaInfo={tabViewData}
+            archiveRef={archiveRef}
+            introduceRef={introduceRef}
+          />
+          {tabViewData.map(
+            ({ title, contents }: { title: string; contents: any }) =>
+              title === '아카이브' ? (
+                <Archive
+                  key={title}
+                  data={contents}
+                  scrollRef={archiveRef}
+                  introYn={tabViewData.length}
+                />
+              ) : title === '소개' ? (
+                <Introduce
+                  key={title}
+                  data={contents}
+                  scrollRef={introduceRef}
+                />
               ) : (
-                <DescriptionInfo
-                  title="입장료"
-                  description={summary?.feeType}
-                />
-              )}
-              {summary?.time ? (
-                <DescriptionInfo
-                  title="시간"
-                  description={
-                    <Box>
-                      <InnerHTML data={summary?.time} />
-                    </Box>
-                  }
-                />
-              ) : null}
-              {summary?.homePageUrl ? (
-                <DescriptionInfo
-                  title="홈페이지"
-                  description={
-                    <Button>
-                      <Link href={summary?.homePageUrl}>
-                        <a target="_blank" rel="noreferrer">
-                          <Span>
-                            바로가기
-                            <Span paddingLeft="8px">{'>'}</Span>
-                          </Span>
-                        </a>
-                      </Link>
-                    </Button>
-                  }
-                />
-              ) : null}
-            </Box>
-            <DetailNavigation
-              deatailMetaInfo={tabViewData}
-              archiveRef={archiveRef}
-              introduceRef={introduceRef}
-            />
-            {tabViewData.map(
-              ({ title, contents }: { title: string; contents: any }) =>
-                title === '아카이브' ? (
-                  <Archive
-                    key={title}
-                    data={contents}
-                    scrollRef={archiveRef}
-                    introYn={tabViewData.length}
-                  />
-                ) : title === '소개' ? (
-                  <Introduce
-                    key={title}
-                    data={contents}
-                    scrollRef={introduceRef}
-                  />
-                ) : (
-                  <div />
-                ),
-            )}
-          </Box>
+                <div />
+              ),
+          )}
         </Box>
-      );
-    case 'loading':
-      return <div>Loading...</div>;
-    case 'hasError':
-      throw Error('상세페이지 정보를 가져오는데 실패했습니다.');
-  }
+      </Box>
+    </Suspense>
+  );
 }

--- a/components/Organisms/Detail/Description.tsx
+++ b/components/Organisms/Detail/Description.tsx
@@ -75,7 +75,16 @@ export default function Description() {
                             <InnerHTML data={summary?.price} />
                           ) : null}
                         </Box>
-                        {isShowLink(summary?.ticketUrl, '티켓 구매하기')}
+                        <Button marginTop="8px">
+                          <Link href={summary?.ticketUrl}>
+                            <a target="_blank" rel="noreferrer">
+                              <Span color={theme.colors.gray99}>
+                                티켓 구매하기
+                                <Span paddingLeft="8px">{'>'}</Span>
+                              </Span>
+                            </a>
+                          </Link>
+                        </Button>
                       </Box>
                     }
                   />
@@ -91,11 +100,25 @@ export default function Description() {
                   title="시간"
                   description={
                     <Box>
-                      <Box>
-                        <InnerHTML data={summary?.time} />
-                      </Box>
-                      {isShowLink(summary?.homePageUrl, '홈페이지 이동')}
+                      <InnerHTML data={summary?.time} />
                     </Box>
+                  }
+                />
+              ) : null}
+              {summary?.homePageUrl ? (
+                <DescriptionInfo
+                  title="홈페이지"
+                  description={
+                    <Button>
+                      <Link href={summary?.homePageUrl}>
+                        <a target="_blank" rel="noreferrer">
+                          <Span>
+                            바로가기
+                            <Span paddingLeft="8px">{'>'}</Span>
+                          </Span>
+                        </a>
+                      </Link>
+                    </Button>
                   }
                 />
               ) : null}

--- a/components/Organisms/Detail/Description.tsx
+++ b/components/Organisms/Detail/Description.tsx
@@ -21,24 +21,6 @@ export default function Description() {
   const archiveRef = createRef<HTMLDivElement>();
   const introduceRef = createRef<HTMLDivElement>();
 
-  const isShowLink = (link: string, title: string) => {
-    if (link) {
-      return (
-        <Button marginTop="8px">
-          <Link href={link}>
-            <a target="_blank" rel="noreferrer">
-              <Span color={theme.colors.gray99}>
-                {title}
-                <Span paddingLeft="8px">{'>'}</Span>
-              </Span>
-            </a>
-          </Link>
-        </Button>
-      );
-    }
-    return;
-  };
-
   switch (state) {
     case 'hasValue':
       return (

--- a/components/Organisms/Detail/Description/Archive.tsx
+++ b/components/Organisms/Detail/Description/Archive.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import Image from 'next/image';
-import { RefObject, useState } from 'react';
+import { RefObject, useEffect, useState } from 'react';
 
 import DetailNoData from 'assets/detail/noData';
 import { Profile } from 'assets/mypage';
@@ -9,7 +9,7 @@ import { CheckBox } from 'components/Atoms/CheckBox';
 import InnerHTML from 'components/Molecules/InnerHTML';
 import StarScope from 'components/Molecules/StarScope';
 import ArchiveHeart from 'components/Organisms/Detail/Description/ArchiveHeart';
-import { ArchiveContents } from 'states/detail';
+import { ArchiveContents, Archives } from 'states/detail';
 import theme from 'styles/theme';
 interface ArchiveProps {
   data: ArchiveContents;
@@ -18,11 +18,21 @@ interface ArchiveProps {
 }
 export default function Archive({ data, scrollRef, introYn }: ArchiveProps) {
   const [checked, setChecked] = useState(false);
+  const [archiveData, setArchiveData] = useState<Archives[]>();
+
+  useEffect(() => {
+    setArchiveData(
+      checked
+        ? data.archives.filter((item) => item.photoUrls.length > 0)
+        : data.archives,
+    );
+  }, [checked, data]);
 
   const onClick = () => {
     setChecked(!checked);
   };
-  if (data.archives.length === 0) {
+
+  if (archiveData?.length === 0) {
     return (
       <Box ref={scrollRef}>
         <Box
@@ -126,7 +136,7 @@ export default function Archive({ data, scrollRef, introYn }: ArchiveProps) {
           </Box>
         </FlexBox>
         <Box paddingTop="20px">
-          {data.archives.map((item, index) => (
+          {archiveData?.map((item, index) => (
             <Box key={index}>
               <Box
                 height="1px"

--- a/components/Organisms/Detail/Description/Archive.tsx
+++ b/components/Organisms/Detail/Description/Archive.tsx
@@ -98,7 +98,11 @@ export default function Archive({ data, scrollRef, introYn }: ArchiveProps) {
   return (
     <Box ref={scrollRef}>
       {introYn === 2 ? <Box paddingTop="80px" /> : null}
-      <FlexBox paddingBottom="18px" justifyContent="space-between">
+      <FlexBox
+        paddingBottom="15px"
+        justifyContent="space-between"
+        paddingTop="30px"
+      >
         <Box fontSize="15px" color={theme.colors.black} fontWeight={500}>
           아카이브
         </Box>

--- a/components/Organisms/Detail/Description/Archive.tsx
+++ b/components/Organisms/Detail/Description/Archive.tsx
@@ -1,10 +1,11 @@
 import { css } from '@emotion/react';
 import Image from 'next/image';
-import { RefObject } from 'react';
+import { RefObject, useState } from 'react';
 
 import DetailNoData from 'assets/detail/noData';
 import { Profile } from 'assets/mypage';
 import { Box, FlexBox, Span, Tag } from 'components/Atoms';
+import { CheckBox } from 'components/Atoms/CheckBox';
 import InnerHTML from 'components/Molecules/InnerHTML';
 import StarScope from 'components/Molecules/StarScope';
 import ArchiveHeart from 'components/Organisms/Detail/Description/ArchiveHeart';
@@ -16,6 +17,10 @@ interface ArchiveProps {
   introYn: number;
 }
 export default function Archive({ data, scrollRef, introYn }: ArchiveProps) {
+  const [checked, setChecked] = useState(false);
+  const onClick = () => {
+    setChecked(!checked);
+  };
   if (data.archives.length === 0) {
     return (
       <Box ref={scrollRef}>
@@ -92,7 +97,23 @@ export default function Archive({ data, scrollRef, introYn }: ArchiveProps) {
   return (
     <Box ref={scrollRef}>
       {introYn === 2 ? <Box paddingTop="80px" /> : null}
-      <Box color={theme.colors.black} fontSize="22px" paddingTop="43px">
+      <FlexBox paddingBottom="18px" justifyContent="space-between">
+        <Box fontSize="15px" color={theme.colors.black} fontWeight={500}>
+          아카이브
+        </Box>
+        <FlexBox alignItems="center">
+          <Box fontSize="12px" color={theme.colors.gray77} paddingRight="10px">
+            사진 아카이브만
+          </Box>
+          <CheckBox
+            type="checkbox"
+            checked={checked ? true : false}
+            onClick={onClick}
+          />
+        </FlexBox>
+      </FlexBox>
+      <Box height="1px" backgroundColor={theme.colors.black} />
+      <Box color={theme.colors.black} fontSize="22px" paddingTop="30px">
         <FlexBox alignItems="center">
           <StartRatingImage />
           <Box paddingLeft="16px">{data.avgStarRating}</Box>

--- a/components/Organisms/Detail/Description/Archive.tsx
+++ b/components/Organisms/Detail/Description/Archive.tsx
@@ -18,6 +18,7 @@ interface ArchiveProps {
 }
 export default function Archive({ data, scrollRef, introYn }: ArchiveProps) {
   const [checked, setChecked] = useState(false);
+
   const onClick = () => {
     setChecked(!checked);
   };
@@ -105,11 +106,7 @@ export default function Archive({ data, scrollRef, introYn }: ArchiveProps) {
           <Box fontSize="12px" color={theme.colors.gray77} paddingRight="10px">
             사진 아카이브만
           </Box>
-          <CheckBox
-            type="checkbox"
-            checked={checked ? true : false}
-            onClick={onClick}
-          />
+          <CheckBox type="checkbox" onChange={onClick} />
         </FlexBox>
       </FlexBox>
       <Box height="1px" backgroundColor={theme.colors.black} />

--- a/components/Organisms/Detail/Description/Summary.tsx
+++ b/components/Organisms/Detail/Description/Summary.tsx
@@ -1,0 +1,84 @@
+import { useRouter } from 'next/dist/client/router';
+import Link from 'next/link';
+import { useRecoilValue } from 'recoil';
+
+import { Box, Button, Span, Tag } from 'components/Atoms';
+import DescriptionInfo from 'components/Molecules/DescriptionInfo';
+import InnerHTML from 'components/Molecules/InnerHTML';
+import { detailSummaryState } from 'states/detail';
+import theme from 'styles/theme';
+
+export default function Summary() {
+  const router = useRouter();
+  const { id } = router.query;
+  const summaryData = useRecoilValue(detailSummaryState(Number(id)));
+
+  return (
+    <Box>
+      <Tag border={`1px solid ${theme.colors.black}`}>{summaryData?.type}</Tag>
+      <Box marginTop="14px" fontSize="19px" fontWeight="500" lineHeight="26px">
+        {summaryData?.title}
+      </Box>
+      <Box marginTop="30px" marginBottom="60px">
+        <DescriptionInfo title="기간" description={summaryData?.term} />
+        <DescriptionInfo title="장소" description={summaryData?.place} />
+        {summaryData?.feeType === '유료' ? (
+          <>
+            <DescriptionInfo
+              title="입장료"
+              description={
+                <Box>
+                  <Box>{summaryData?.feeType}</Box>
+                  <Box>
+                    {summaryData?.price ? (
+                      <InnerHTML data={summaryData?.price} />
+                    ) : null}
+                  </Box>
+                  <Button marginTop="8px">
+                    <Link href={summaryData?.ticketUrl}>
+                      <a target="_blank" rel="noreferrer">
+                        <Span color={theme.colors.gray99}>
+                          티켓 구매하기
+                          <Span paddingLeft="8px">{'>'}</Span>
+                        </Span>
+                      </a>
+                    </Link>
+                  </Button>
+                </Box>
+              }
+            />
+          </>
+        ) : (
+          <DescriptionInfo title="입장료" description={summaryData?.feeType} />
+        )}
+        {summaryData?.time ? (
+          <DescriptionInfo
+            title="시간"
+            description={
+              <Box>
+                <InnerHTML data={summaryData?.time} />
+              </Box>
+            }
+          />
+        ) : null}
+        {summaryData?.homePageUrl ? (
+          <DescriptionInfo
+            title="홈페이지"
+            description={
+              <Button>
+                <Link href={summaryData?.homePageUrl}>
+                  <a target="_blank" rel="noreferrer">
+                    <Span>
+                      바로가기
+                      <Span paddingLeft="8px">{'>'}</Span>
+                    </Span>
+                  </a>
+                </Link>
+              </Button>
+            }
+          />
+        ) : null}
+      </Box>
+    </Box>
+  );
+}

--- a/components/Organisms/Detail/Description/Summary.tsx
+++ b/components/Organisms/Detail/Description/Summary.tsx
@@ -5,37 +5,35 @@ import { useRecoilValue } from 'recoil';
 import { Box, Button, Span, Tag } from 'components/Atoms';
 import DescriptionInfo from 'components/Molecules/DescriptionInfo';
 import InnerHTML from 'components/Molecules/InnerHTML';
-import { detailSummaryState } from 'states/detail';
+import { DetailState } from 'states';
 import theme from 'styles/theme';
 
 export default function Summary() {
-  const router = useRouter();
-  const { id } = router.query;
-  const summaryData = useRecoilValue(detailSummaryState(Number(id)));
-
+  const data = useRecoilValue(DetailState);
+  const { summary } = data;
   return (
     <Box>
-      <Tag border={`1px solid ${theme.colors.black}`}>{summaryData?.type}</Tag>
+      <Tag border={`1px solid ${theme.colors.black}`}>{summary?.type}</Tag>
       <Box marginTop="14px" fontSize="19px" fontWeight="500" lineHeight="26px">
-        {summaryData?.title}
+        {summary?.title}
       </Box>
       <Box marginTop="30px" marginBottom="60px">
-        <DescriptionInfo title="기간" description={summaryData?.term} />
-        <DescriptionInfo title="장소" description={summaryData?.place} />
-        {summaryData?.feeType === '유료' ? (
+        <DescriptionInfo title="기간" description={summary?.term} />
+        <DescriptionInfo title="장소" description={summary?.place} />
+        {summary?.feeType === '유료' ? (
           <>
             <DescriptionInfo
               title="입장료"
               description={
                 <Box>
-                  <Box>{summaryData?.feeType}</Box>
+                  <Box>{summary?.feeType}</Box>
                   <Box>
-                    {summaryData?.price ? (
-                      <InnerHTML data={summaryData?.price} />
+                    {summary?.price ? (
+                      <InnerHTML data={summary?.price} />
                     ) : null}
                   </Box>
                   <Button marginTop="8px">
-                    <Link href={summaryData?.ticketUrl}>
+                    <Link href={summary?.ticketUrl}>
                       <a target="_blank" rel="noreferrer">
                         <Span color={theme.colors.gray99}>
                           티켓 구매하기
@@ -49,24 +47,24 @@ export default function Summary() {
             />
           </>
         ) : (
-          <DescriptionInfo title="입장료" description={summaryData?.feeType} />
+          <DescriptionInfo title="입장료" description={summary?.feeType} />
         )}
-        {summaryData?.time ? (
+        {summary?.time ? (
           <DescriptionInfo
             title="시간"
             description={
               <Box>
-                <InnerHTML data={summaryData?.time} />
+                <InnerHTML data={summary?.time} />
               </Box>
             }
           />
         ) : null}
-        {summaryData?.homePageUrl ? (
+        {summary?.homePageUrl ? (
           <DescriptionInfo
             title="홈페이지"
             description={
               <Button>
-                <Link href={summaryData?.homePageUrl}>
+                <Link href={summary?.homePageUrl}>
                   <a target="_blank" rel="noreferrer">
                     <Span>
                       바로가기

--- a/components/Organisms/Detail/ExhibitionImagesSection.tsx
+++ b/components/Organisms/Detail/ExhibitionImagesSection.tsx
@@ -1,5 +1,4 @@
 import Image from 'next/image';
-import { useRouter } from 'next/router';
 import { useRecoilValueLoadable } from 'recoil';
 
 import noImage from 'assets/common/no_image_375x500.png';
@@ -7,9 +6,7 @@ import { Box } from 'components/Atoms';
 import { DetailState } from 'states';
 
 export default function ExhibitionImagesSection() {
-  const router = useRouter();
-  const { id } = router.query;
-  const state = useRecoilValueLoadable(DetailState(Number(id)));
+  const state = useRecoilValueLoadable(DetailState);
   const detailImageUrl = state?.contents?.summary?.detailImageUrl;
 
   return (

--- a/components/Organisms/Detail/Navigator.tsx
+++ b/components/Organisms/Detail/Navigator.tsx
@@ -23,7 +23,7 @@ export default function Navigator() {
   const setAlertState = useSetRecoilState(AlertState);
   const setPopupName = useSetRecoilState(PopupNameState);
   const { id } = router.query;
-  const { contents, state } = useRecoilValueLoadable(DetailState(Number(id)));
+  const { contents, state } = useRecoilValueLoadable(DetailState);
   const data: TGetSummary = contents?.summary;
   const loginState = useRecoilValue(User);
 

--- a/pages/detail/[id]/index.tsx
+++ b/pages/detail/[id]/index.tsx
@@ -11,9 +11,9 @@ export default function Detail() {
   return (
     <Box backgroundColor={theme.colors.grayEE}>
       <Box height="5px" />
-      <ExhibitionImagesSection />
+      {/* <ExhibitionImagesSection /> */}
       <Description />
-      <Navigator />
+      {/* <Navigator /> */}
     </Box>
   );
 }

--- a/pages/detail/[id]/index.tsx
+++ b/pages/detail/[id]/index.tsx
@@ -1,19 +1,27 @@
+import { useEffect } from 'react';
+
 import { Box } from 'components/Atoms';
 import Description from 'components/Organisms/Detail/Description';
 import ExhibitionImagesSection from 'components/Organisms/Detail/ExhibitionImagesSection';
 import Navigator from 'components/Organisms/Detail/Navigator';
+import { useResetDetailArchiveFunction } from 'states/detail';
 import theme from 'styles/theme';
 import { useInitHeader } from 'utils/hooks/useInitHeader';
 
 export default function Detail() {
   useInitHeader({ headerLeft: 'default', headerEnd: 'home' });
+  const resetArchiveState = useResetDetailArchiveFunction();
+
+  useEffect(() => {
+    resetArchiveState();
+  }, [resetArchiveState]);
 
   return (
     <Box backgroundColor={theme.colors.grayEE}>
       <Box height="5px" />
-      {/* <ExhibitionImagesSection /> */}
+      <ExhibitionImagesSection />
       <Description />
-      {/* <Navigator /> */}
+      <Navigator />
     </Box>
   );
 }

--- a/states/detail.ts
+++ b/states/detail.ts
@@ -42,7 +42,22 @@ type TGetIntroduction = {
   photo: string[] | [];
   summary: string | null;
 };
-
+export interface Archives {
+  id: number;
+  userProfileUrl: string;
+  userName: string;
+  updatedAt: string;
+  starRating: number;
+  likeCount: number;
+  heart: {
+    heartClicked: boolean;
+    link: string;
+  };
+  comment: string;
+  food: string;
+  cafe: string;
+  photoUrls: string[];
+}
 export interface ArchiveContents {
   responsePagingStatus: {
     nextPage: number;
@@ -53,22 +68,7 @@ export interface ArchiveContents {
     currentContentsCount: number;
   };
   avgStarRating: number;
-  archives: {
-    id: number;
-    userProfileUrl: string;
-    userName: string;
-    updatedAt: string;
-    starRating: number;
-    likeCount: number;
-    heart: {
-      heartClicked: boolean;
-      link: string;
-    };
-    comment: string;
-    food: string;
-    cafe: string;
-    photoUrls: string[];
-  }[];
+  archives: Archives[];
 }
 
 type TGetArchive = {

--- a/states/index.ts
+++ b/states/index.ts
@@ -1,13 +1,13 @@
 import AlertState from './alertState';
 import { ArchiveWriteState } from './archiveWirte';
-import { DetailState } from './detail';
+import { detailState } from './detail';
 import MyArchiveListState from './myArchiveList';
 import PopupNameState from './popupName';
 
 import { searchRequest } from 'states/search-request';
 
 export {
-  DetailState,
+  detailState as DetailState,
   ArchiveWriteState,
   searchRequest,
   MyArchiveListState,


### PR DESCRIPTION
## **📄 PR 카테고리**

- ⬜️ 리팩토링
- ⬜️ 화면 개발 ( 추가, 수정, 삭제 )
- ✅ QA 및 버그 수정
- ⬜️ 기타 ( 버전 업데이트 등 )

## **⌨️ 변경점**

1.홈페이지 바로가기 수정
<img width="300" alt="image" src="https://user-images.githubusercontent.com/48988891/194736879-442a0a25-e237-450f-a9fb-c4eb7332a31c.png">

2.돋보기와 홈 아이콘 간격 조절
<img width="322" alt="image" src="https://user-images.githubusercontent.com/48988891/194736681-4e215704-82c9-4634-a454-241886e3ea62.png">


3.아카이브 제목 부분 추가
<img width="320" alt="image" src="https://user-images.githubusercontent.com/48988891/194736866-0f4922c2-d54b-4e0f-88a1-6ef842a0b41d.png">

4. 아카이브 기록하기 후 내가쓴 아카이브 바로보임
5. 사진 아카이브만 눌렀을 때 사진 아카이브만 노출


## **🤦🏻 고민한 부분**

## **🙋🏼‍♀️ 추가 논의가 필요한 부분**

## **✋ 추가 코멘트**

아카이브 제목 부분에 사진아카이브만 보기 로직 추가해야 함