### PR TITLE
[add] 마이아카이브 디테일 화면 개발 완료, 마이아카이브 재진입시 state 업데이트, 마이아카이브 갯수 표시 (#123)

### DIFF
--- a/components/Organisms/MyPage/Archive/BlankArchiveListSection.tsx
+++ b/components/Organisms/MyPage/Archive/BlankArchiveListSection.tsx
@@ -1,5 +1,5 @@
 import Alert from 'assets/error/Alert';
-import { Box, FlexBox } from 'components/Atoms';
+import { Box } from 'components/Atoms';
 
 export default function BlankArchiveListSection() {
   return (

--- a/components/Organisms/MyPage/Archive/Detail/MyArchiveDetailCard.tsx
+++ b/components/Organisms/MyPage/Archive/Detail/MyArchiveDetailCard.tsx
@@ -1,0 +1,73 @@
+import { css } from '@emotion/react';
+
+import { Box } from 'components/Atoms';
+import Carousel from 'components/Molecules/Carousel';
+import InnerHTML from 'components/Molecules/InnerHTML';
+import NoItemBox from 'components/Molecules/NoItemBox';
+import MyArchiveDetailHeaderInfo from 'components/Organisms/MyPage/Archive/Detail/MyArchiveDetailCardHeader';
+import MyArchiveDetailCardInfo from 'components/Organisms/MyPage/Archive/Detail/MyArchiveDetailCardInfo';
+import { MyArchiveDetailProps } from 'states/myArchiveDetail';
+import theme from 'styles/theme';
+
+export default function MyArchiveDetailCard(contents: MyArchiveDetailProps) {
+  return (
+    <Box background="#fff" width="345px" height="652px" margin="15px">
+      <MyArchiveDetailHeaderInfo
+        updatedAt={contents.updatedAt}
+        typeBadge={contents.typeBadge}
+        title={contents.title}
+        archiveAdditionalInfos={contents.archiveAdditionalInfos}
+      />
+      <Box
+        width="100%"
+        height="347px"
+        borderTop="solid 1px"
+        borderTopColor={theme.colors.gray99}
+        borderBottom="solid 1px"
+        borderBottomColor={theme.colors.gray99}
+      >
+        {contents.photoUrls.length === 0 ? (
+          <NoItemBox width="inherit" height="inherit" text="사진 " />
+        ) : (
+          <Carousel
+            imgUrlArr={contents.photoUrls}
+            width={'345px'}
+            height={'345px'}
+          />
+        )}
+      </Box>
+      <Box
+        height="88px"
+        margin="20px 5px"
+        overflowY="auto"
+        fontSize="12px"
+        textAlign="left"
+        lineHeight="18px"
+        css={css`
+          ::-webkit-scrollbar {
+            display: block;
+            width: 2px;
+            height: 100%;
+            background: gray;
+          }
+          ::-webkit-scrollbar-thumb {
+            background: #000;
+          }
+        `}
+      >
+        {contents.comment === '' ? (
+          <NoItemBox width="inherit" height="inherit" text="코멘트" />
+        ) : (
+          <Box width="inherit" height="fit-content" margin="0 10px">
+            <InnerHTML data={contents.comment} />
+          </Box>
+        )}
+      </Box>
+      <MyArchiveDetailCardInfo
+        starRating={contents.starRating}
+        food={contents.food}
+        cafe={contents.cafe}
+      />
+    </Box>
+  );
+}

--- a/components/Organisms/MyPage/Archive/Detail/MyArchiveDetailCardHeader.tsx
+++ b/components/Organisms/MyPage/Archive/Detail/MyArchiveDetailCardHeader.tsx
@@ -1,0 +1,110 @@
+import { css } from '@emotion/react';
+import { useRouter } from 'next/router';
+import { useSetRecoilState, useRecoilValue } from 'recoil';
+
+import { Box, Button, FlexBox, Span, Tag } from 'components/Atoms';
+import { ALERT_MESSAGE } from 'constants/alertMessage';
+import { POPUP_NAME } from 'constants/popupName';
+import { AlertState, PopupNameState } from 'states';
+import { TGetSummary } from 'states/detail';
+import {
+  MyArchiveDetailProps,
+  MyArchiveDetailHeaderInfoProps,
+  ClickedArchiveId,
+} from 'states/myArchiveDetail';
+import theme from 'styles/theme';
+
+export default function MyArchiveDetailHeaderInfo(
+  props: MyArchiveDetailHeaderInfoProps,
+) {
+  const router = useRouter();
+  const id = useRecoilValue(ClickedArchiveId);
+  const setAlertState = useSetRecoilState(AlertState);
+  const setPopupName = useSetRecoilState(PopupNameState);
+  const handleClosePopup = () => {
+    setPopupName(POPUP_NAME.NULL);
+  };
+
+  const handleUpdateArchive = () => {
+    handleClosePopup();
+    archiveLink();
+  };
+
+  const archiveLink = () => {
+    return router.push({
+      pathname: `/archive/update`,
+      query: {
+        id: id,
+        title: props?.title,
+        thumbnailImageUrl: '',
+        checked: true,
+      },
+    });
+  };
+
+  const handleDeleteArchive = () => {
+    setAlertState(ALERT_MESSAGE.ALERT.ARCHIVE_DELETE_CONFIRM);
+    setPopupName(POPUP_NAME.ALERT_ARCHIVE_DELETE_CANCEL_CONFIRM);
+  };
+
+  return (
+    <Box height="99px" padding="20px 15px">
+      <FlexBox justifyContent="space-between">
+        <Box fontSize="11px" display="flex" alignItems="center">
+          <Tag
+            backgroundColor={theme.colors.white}
+            color={theme.colors.black}
+            border="1px solid"
+          >
+            {props.typeBadge.text}
+          </Tag>
+          <Span marginLeft="5px" color={theme.colors.gray99}>
+            {props.updatedAt}
+          </Span>
+        </Box>
+        <Box>
+          <Button
+            fontSize="12px"
+            lineHeight="16px"
+            color={theme.colors.gray77}
+            marginRight="16px"
+            borderBottom="1px solid"
+            borderBottomColor={theme.colors.gray77}
+            onClick={() => {
+              handleUpdateArchive();
+            }}
+          >
+            수정
+          </Button>
+          <Button
+            fontSize="12px"
+            lineHeight="16px"
+            color={theme.colors.gray77}
+            borderBottom="1px solid"
+            borderBottomColor={theme.colors.gray77}
+            onClick={() => {
+              handleDeleteArchive();
+            }}
+          >
+            삭제
+          </Button>
+        </Box>
+      </FlexBox>
+      <Box
+        fontSize="15px"
+        marginTop="20px"
+        lineHeight="22px"
+        fontWeight="Bold"
+        overflow="hidden"
+        display="-webkit-box"
+        css={css`
+          text-overflow: ellipsis;
+          -webkit-line-clamp: 1;
+          -webkit-box-orient: vertical;
+        `}
+      >
+        {props.title}
+      </Box>
+    </Box>
+  );
+}

--- a/components/Organisms/MyPage/Archive/Detail/MyArchiveDetailCardInfo.tsx
+++ b/components/Organisms/MyPage/Archive/Detail/MyArchiveDetailCardInfo.tsx
@@ -1,0 +1,128 @@
+import { css } from '@emotion/react';
+
+import { Pointer } from 'assets/mypage';
+import { Box, FlexBox, Span } from 'components/Atoms';
+import NoItemBox from 'components/Molecules/NoItemBox';
+import { MyArchiveDetailInfoProps } from 'states/myArchiveDetail';
+import theme from 'styles/theme';
+
+export default function MyArchiveDetailCardInfo(
+  contents: MyArchiveDetailInfoProps,
+) {
+  const makeAvgStarRating = () => {
+    const rating = contents.starRating * 20;
+    return `${rating + 1.5}%`;
+  };
+
+  const Start = () => {
+    return (
+      <Span width="21px" height="20px" paddingLeft="6px">
+        ★
+      </Span>
+    );
+  };
+
+  return (
+    <FlexBox borderTop="solid 1px" borderTopColor={theme.colors.gray99}>
+      {/* 다녀온곳 */}
+      <Box width="172.5px" height="80px">
+        {contents.cafe === '' && contents.food === '' ? (
+          <NoItemBox width="inherit" height="inherit" text="다녀온 곳" />
+        ) : (
+          <FlexBox
+            width="inherit"
+            height="inherit"
+            padding="20px 15px"
+            background={theme.colors.black}
+            flexDirection="column"
+            justifyContent="center"
+          >
+            <Box display={contents.food ? 'flex' : 'none'} alignItems="center">
+              <Box display={contents.food ? 'block' : 'none'}>
+                <Pointer color="#fff" />
+              </Box>
+              <Span
+                marginLeft="10px"
+                fontSize="12px"
+                lineHeight="18px"
+                display="-webkit-box"
+                overflow="hidden"
+                color="#fff"
+                css={css`
+                  text-overflow: ellipsis;
+                  -webkit-line-clamp: 1;
+                  -webkit-box-orient: vertical;
+                `}
+              >
+                {contents.food}
+              </Span>
+            </Box>
+            <Box display={contents.cafe ? 'flex' : 'none'} alignItems="center">
+              <Box display={contents.cafe ? 'block' : 'none'}>
+                <Pointer color="#fff" />
+              </Box>
+              <Box
+                marginLeft="10px"
+                fontSize="12px"
+                lineHeight="18px"
+                overflow="hidden"
+                display="-webkit-box"
+                color="#fff"
+                css={css`
+                  text-overflow: ellipsis;
+                  -webkit-line-clamp: 1;
+                  -webkit-box-orient: vertical;
+                `}
+              >
+                {contents.cafe}
+              </Box>
+            </Box>
+          </FlexBox>
+        )}
+      </Box>
+      <FlexBox
+        width="172.5px"
+        height="80px"
+        justifyContent="center"
+        alignItems="center"
+        borderLeft="solid 1px"
+        borderColor={theme.colors.gray99}
+      >
+        <Box
+          color={theme.colors.black}
+          position="relative"
+          width="max-content"
+          css={css`
+            unicode-bidi: bidi-override;
+            -webkit-text-fill-color: transparent;
+            -webkit-text-stroke-width: 1.3px;
+            -webkit-text-stroke-color: orange;
+          `}
+        >
+          <Box
+            position="absolute"
+            zIndex="1"
+            overflow="hidden"
+            css={css`
+              -webkit-text-fill-color: orange;
+            `}
+            width={makeAvgStarRating()}
+          >
+            <Start />
+            <Start />
+            <Start />
+            <Start />
+            <Start />
+          </Box>
+          <Box zIndex="0" padding="0">
+            <Start />
+            <Start />
+            <Start />
+            <Start />
+            <Start />
+          </Box>
+        </Box>
+      </FlexBox>
+    </FlexBox>
+  );
+}

--- a/components/Organisms/MyPage/Archive/ItemImage.tsx
+++ b/components/Organisms/MyPage/Archive/ItemImage.tsx
@@ -1,6 +1,4 @@
-import { css } from '@emotion/react';
 import Image from 'next/image';
-import { useRouter } from 'next/router';
 
 import { Box } from 'components/Atoms';
 

--- a/components/Organisms/MyPage/Archive/ListCard.tsx
+++ b/components/Organisms/MyPage/Archive/ListCard.tsx
@@ -10,15 +10,6 @@ import { POPUP_NAME } from 'constants/popupName';
 import { PopupNameState } from 'states';
 import { ClickedArchiveId } from 'states/myArchiveDetail';
 import { MyArchivePageContents } from 'states/myArchiveList';
-// const af = styled.li`
-//   &:before {
-//     content: '·';
-//     font-size: 20px;
-//     vertical-align: middle;
-//     line-height: 20px;
-//     padding-right: 5px;
-//   }
-// `;
 
 type ItemProps = {
   content: MyArchivePageContents;
@@ -28,16 +19,14 @@ export default function Item(props: ItemProps) {
   const content = props.content;
   const setPopupName = useSetRecoilState(PopupNameState);
   const setArchiveId = useSetRecoilState(ClickedArchiveId);
-  // 아카이브id 값 만들기
-  // ex) /api/archive/596 => ["","api","archive","596"]
-  const apiArr = content.api.split('/');
 
+  const apiArr = content.api.split('/');
   return (
     <FlexBox
       position="relative"
       padding="0px 0px 40px"
       onClick={() => {
-        setArchiveId(apiArr[3]);
+        setArchiveId(apiArr[4]);
         setPopupName(POPUP_NAME.POPUP_ARCHIVE_DETAIL);
       }}
       css={css`

--- a/components/Organisms/MyPage/Archive/ListSection.tsx
+++ b/components/Organisms/MyPage/Archive/ListSection.tsx
@@ -1,32 +1,18 @@
-import { useRecoilValueLoadable } from 'recoil';
-
-import BlankArchiveListSection from './BlankArchiveListSection';
 import ListCard from './ListCard';
 
 import { Box } from 'components/Atoms';
-import { MyArchiveListState } from 'states';
+import { MyArchivePageContents } from 'states/myArchiveList';
 
-export default function ListSection() {
-  const data = useRecoilValueLoadable(MyArchiveListState);
-
-  switch (data.state) {
-    case 'hasValue':
-      if (data.contents.contents.length === 0) {
-        return <BlankArchiveListSection />;
-      }
-
-      return (
-        <>
-          <Box marginBottom="60px">
-            {data.contents.contents.map((content, index) => (
-              <ListCard key={content?.api ?? index} content={content} />
-            ))}
-          </Box>
-        </>
-      );
-    case 'loading':
-      return <div>Loading...</div>;
-    case 'hasError':
-      throw data.contents;
-  }
+export default function ListSection(data: any) {
+  return (
+    <>
+      <Box marginBottom="60px">
+        {data?.contents?.contents?.map(
+          (content: MyArchivePageContents, index: number) => (
+            <ListCard key={content?.api ?? index} content={content} />
+          ),
+        )}
+      </Box>
+    </>
+  );
 }

--- a/components/Organisms/MyPage/Archive/MyArchiveListFragment.tsx
+++ b/components/Organisms/MyPage/Archive/MyArchiveListFragment.tsx
@@ -1,20 +1,10 @@
-import { useRouter } from 'next/router';
-
-import BlankArchiveListSection from './BlankArchiveListSection';
 import ListSection from './ListSection';
 
-import { Box, Button, Layout } from 'components/Atoms';
-import theme from 'styles/theme';
-
 export default function MyArchiveListFragment() {
-  const router = useRouter();
-
   return (
     <>
       <div></div>
-
       <ListSection />
     </>
-    // <BlankArchiveListSection />
   );
 }

--- a/components/Organisms/MyPage/MyPageInfoFragment.tsx
+++ b/components/Organisms/MyPage/MyPageInfoFragment.tsx
@@ -1,57 +1,76 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { useRecoilValue, useRecoilValueLoadable } from 'recoil';
 
 import { Box } from 'components/Atoms';
 import ListSection from 'components/Organisms/MyPage/Archive/ListSection';
 import ConfigurationFragment from 'components/Organisms/MyPage/ConfigurationFragment';
+import { useResetMyArchiveListStateFunction } from 'states/myArchiveList';
+import { myArchiveListState } from 'states/myArchiveList';
 import theme from 'styles/theme';
 
-const MyPageNavigatorMetaInfo = [{ title: 'MY 아카이브' }, { title: '설정' }];
-
 export default function MyPageInfoFragment() {
+  const { state, contents } = useRecoilValueLoadable(myArchiveListState);
+  const MyPageNavigatorMetaInfo = [
+    { title: `${contents?.title ?? ''}` },
+    { title: '설정' },
+  ];
   const [isMyArchiveShowed, setMyArhiveShowedFlag] = useState<boolean>(true);
   const clicked = isMyArchiveShowed ? 0 : 1;
 
-  const renderFragment = (title: string) => {
-    if (title === 'MY 아카이브') {
+  const renderFragment = (index: number) => {
+    if (index === 0) {
       setMyArhiveShowedFlag(true);
     } else {
       setMyArhiveShowedFlag(false);
     }
   };
-  return (
-    <>
-      <Box
-        position="sticky"
-        top="calc(45px + env(safe-area-inset-top))"
-        background={theme.colors.white}
-        zIndex={2}
-      >
-        <Box height="45px" overflow="auto" display="flex" zIndex={2}>
-          {MyPageNavigatorMetaInfo.map(({ title }, index) => (
-            <Box
-              key={title}
-              flex="1"
-              display="flex"
-              alignItems="center"
-              justifyContent="center"
-              fontSize="17px"
-              fontWeight={500}
-              borderBottom={
-                clicked === index
-                  ? `2px solid ${theme.colors.black}`
-                  : `2px solid ${theme.colors.grayDD}`
-              }
-              color={
-                clicked === index ? theme.colors.black : theme.colors.gray99
-              }
-              onClick={() => renderFragment(title)}
-            >
-              {title}
+
+  switch (state) {
+    case 'hasValue':
+      return (
+        <>
+          <Box
+            position="sticky"
+            top="calc(45px + env(safe-area-inset-top))"
+            background={theme.colors.white}
+            zIndex={2}
+          >
+            <Box height="45px" overflow="auto" display="flex" zIndex={2}>
+              {MyPageNavigatorMetaInfo.map(({ title }, index) => (
+                <Box
+                  key={title}
+                  flex="1"
+                  display="flex"
+                  alignItems="center"
+                  justifyContent="center"
+                  fontSize="17px"
+                  fontWeight={500}
+                  borderBottom={
+                    clicked === index
+                      ? `2px solid ${theme.colors.black}`
+                      : `2px solid ${theme.colors.grayDD}`
+                  }
+                  color={
+                    clicked === index ? theme.colors.black : theme.colors.gray99
+                  }
+                  onClick={() => renderFragment(index)}
+                >
+                  {title}
+                </Box>
+              ))}
             </Box>
-          ))}
-        </Box>
-      </Box>
-      {isMyArchiveShowed ? <ListSection /> : <ConfigurationFragment />}
-    </>
-  );
+          </Box>
+          {isMyArchiveShowed ? (
+            <ListSection contents={contents} />
+          ) : (
+            <ConfigurationFragment />
+          )}
+        </>
+      );
+
+    case 'loading':
+      return <div>loading</div>;
+    case 'hasError':
+      throw contents;
+  }
 }

--- a/components/Organisms/Popup/AlertArchiveDeletePopup.tsx
+++ b/components/Organisms/Popup/AlertArchiveDeletePopup.tsx
@@ -1,0 +1,89 @@
+import axios from 'axios';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+
+import { Box, Button } from 'components/Atoms';
+import Popup from 'components/Molecules/Popup';
+import { POPUP_NAME } from 'constants/popupName';
+import { AlertState, PopupNameState } from 'states';
+import { ClickedArchiveId } from 'states/myArchiveDetail';
+import theme from 'styles/theme';
+import customAxios from 'utils/hooks/customAxios';
+
+/** TODO: 취소 및 확인 누른 후 액션에 대한 정의필요 */
+
+const AlertArchiveDeletePopup = () => {
+  const alertState = useRecoilValue(AlertState);
+  const setPopupName = useSetRecoilState(PopupNameState);
+  const clickedArchiveIdState = useRecoilValue(ClickedArchiveId);
+
+  const [response, setResponse] = useState('');
+  const [readStatus, writeStatus] = useState('');
+
+  const router = useRouter();
+
+  const dd = async () => {
+    const axios = customAxios();
+    const { data } = await axios({
+      url: `/api/archive/${clickedArchiveIdState.toString()}`,
+      method: 'DELETE',
+    });
+
+    return data;
+  };
+
+  const aaa = () => {
+    dd().then(() => {
+      setResponse('success');
+    });
+  };
+
+  const handleCancel = () => {
+    setPopupName(POPUP_NAME.POPUP_ARCHIVE_DETAIL);
+  };
+
+  return (
+    <Popup>
+      <Box
+        width="315px"
+        borderRadius="12px"
+        height="167px"
+        backgroundColor={theme.colors.white}
+      >
+        <Box padding="50px 40px">
+          <Box
+            fontSize="13px"
+            lineHeight="1.54"
+            textAlign="center"
+            color={theme.colors.black}
+          >
+            {alertState.message}
+          </Box>
+        </Box>
+        <Button
+          height="50px"
+          width="50%"
+          fontSize="16px"
+          borderRadius="0 0 0 12px"
+          backgroundColor={theme.colors.grayEE}
+          onClick={handleCancel}
+        >
+          <Box color={theme.colors.black}>취소</Box>
+        </Button>
+        <Button
+          height="50px"
+          width="50%"
+          fontSize="16px"
+          borderRadius="0 0 12px 0"
+          backgroundColor={theme.colors.black}
+          onClick={aaa}
+        >
+          <Box color={theme.colors.white}>확인</Box>
+        </Button>
+      </Box>
+    </Popup>
+  );
+};
+
+export default AlertArchiveDeletePopup;

--- a/components/Organisms/Popup/MyArchiveDetailPopup.tsx
+++ b/components/Organisms/Popup/MyArchiveDetailPopup.tsx
@@ -1,31 +1,23 @@
-import { css } from '@emotion/react';
-import Image from 'next/image';
 import { useRecoilValueLoadable, useSetRecoilState } from 'recoil';
 
-import StarRating from 'assets/list/StarRating';
-import { Pointer, CloseBtn } from 'assets/mypage';
-import { Box, Button, FlexBox, Span, Tag } from 'components/Atoms';
-import Carousel from 'components/Molecules/Carousel';
+import { CloseBtn } from 'assets/mypage';
+import { Box, Button } from 'components/Atoms';
 import Popup from 'components/Molecules/Popup';
+import MyArchiveDetailCard from 'components/Organisms/MyPage/Archive/Detail/MyArchiveDetailCard';
 import { POPUP_NAME } from 'constants/popupName';
 import { PopupNameState } from 'states';
 import { myArchiveDetailInfoState } from 'states/myArchiveDetail';
-import theme from 'styles/theme';
 
 const MyArchiveDetailPopup = () => {
   const data = useRecoilValueLoadable(myArchiveDetailInfoState);
 
   const setPopupName = useSetRecoilState(PopupNameState);
-
   const handleClosePopup = () => {
     setPopupName(POPUP_NAME.NULL);
   };
+
   switch (data.state) {
     case 'hasValue':
-      if (data.contents.length === 0) {
-        return <Box>데이터 불러오기 실패</Box>;
-      }
-
       return (
         <Popup>
           <Box>
@@ -34,180 +26,17 @@ const MyArchiveDetailPopup = () => {
                 <CloseBtn />
               </Button>
             </Box>
-            <Box background="#fff" width="345px" height="652px" margin="15px">
-              <Box
-                height="99px"
-                padding="20px 15px"
-                borderBottom="1px solid"
-                borderBottomColor={theme.colors.gray77}
-              >
-                <FlexBox justifyContent="space-between">
-                  <Box fontSize="11px" display="flex" alignItems="center">
-                    <Tag
-                      backgroundColor={theme.colors.white}
-                      color={theme.colors.black}
-                      border="1px solid"
-                    >
-                      {data.contents.typeBadge.text}
-                    </Tag>
-                    <Span marginLeft="5px" color={theme.colors.gray99}>
-                      {data.contents.updatedAt}
-                    </Span>
-                  </Box>
-                  <Box>
-                    <Button
-                      fontSize="12px"
-                      lineHeight="16px"
-                      color={theme.colors.gray77}
-                      marginRight="16px"
-                      borderBottom="1px solid"
-                      borderBottomColor={theme.colors.gray77}
-                    >
-                      수정
-                    </Button>
-                    <Button
-                      fontSize="12px"
-                      lineHeight="16px"
-                      color={theme.colors.gray77}
-                      borderBottom="1px solid"
-                      borderBottomColor={theme.colors.gray77}
-                    >
-                      삭제
-                    </Button>
-                  </Box>
-                </FlexBox>
-                <Box
-                  fontSize="15px"
-                  marginTop="20px"
-                  lineHeight="22px"
-                  fontWeight="Bold"
-                  overflow="hidden"
-                  display="-webkit-box"
-                  css={css`
-                    text-overflow: ellipsis;
-                    -webkit-line-clamp: 1;
-                    -webkit-box-orient: vertical;
-                  `}
-                >
-                  {data.contents.title}
-                </Box>
-              </Box>
-              <Carousel
-                imgUrlArr={data.contents.photoUrls}
-                width={'345px'}
-                height={'345px'}
-              />
-              <Box
-                height="88px"
-                margin="20px 5px"
-                overflowY="scroll"
-                fontSize="12px"
-                textAlign="left"
-                lineHeight="18px"
-                css={css`
-                  ::-webkit-scrollbar {
-                    display: block;
-                    width: 2px;
-                    height: 100%;
-                    background: gray;
-                  }
-                  ::-webkit-scrollbar-thumb {
-                    background: #000;
-                  }
-                `}
-              >
-                <Box margin="0 10px">{data.contents.comment}</Box>
-              </Box>
-              <FlexBox
-                borderTop="solid 1px"
-                borderTopColor={theme.colors.gray99}
-              >
-                <Box
-                  width="172.5px"
-                  height="80px"
-                  background="#000"
-                  padding="20px 15px"
-                >
-                  <FlexBox alignItems="center">
-                    <Box display={data.contents.food ? 'visible' : 'none'}>
-                      <Pointer color="#fff" />
-                    </Box>
-                    <Span
-                      marginLeft="10px"
-                      fontSize="12px"
-                      lineHeight="18px"
-                      display="-webkit-box"
-                      overflow="hidden"
-                      color="#fff"
-                      css={css`
-                        text-overflow: ellipsis;
-                        -webkit-line-clamp: 1;
-                        -webkit-box-orient: vertical;
-                      `}
-                    >
-                      {data.contents.food}
-                    </Span>
-                  </FlexBox>
-                  <FlexBox alignItems="center">
-                    <Box display={data.contents.cafe ? 'visible' : 'none'}>
-                      <Pointer color="#fff" />
-                    </Box>
-                    <Box
-                      marginLeft="10px"
-                      fontSize="12px"
-                      lineHeight="18px"
-                      overflow="hidden"
-                      display="-webkit-box"
-                      color="#fff"
-                      css={css`
-                        text-overflow: ellipsis;
-                        -webkit-line-clamp: 1;
-                        -webkit-box-orient: vertical;
-                      `}
-                    >
-                      {data.contents.cafe}
-                    </Box>
-                  </FlexBox>
-                </Box>
-                <FlexBox
-                  width="172.5px"
-                  height="80px"
-                  justifyContent="center"
-                  alignItems="center"
-                >
-                  <StarRating
-                    width="21.6px"
-                    height="20.6px"
-                    viewBox="0 0 10 10"
-                    fill={theme.colors.orange}
-                  />
-                  <StarRating
-                    width="21.6px"
-                    height="20.6px"
-                    viewBox="0 0 10 10"
-                    fill={theme.colors.orange}
-                  />
-                  <StarRating
-                    width="21.6px"
-                    height="20.6px"
-                    viewBox="0 0 10 10"
-                    fill={theme.colors.orange}
-                  />
-                  <StarRating
-                    width="21.6px"
-                    height="20.6px"
-                    viewBox="0 0 10 10"
-                    fill={theme.colors.orange}
-                  />
-                  <StarRating
-                    width="21.6px"
-                    height="20.6px"
-                    viewBox="0 0 10 10"
-                    fill={theme.colors.orange}
-                  />
-                </FlexBox>
-              </FlexBox>
-            </Box>
+            <MyArchiveDetailCard
+              typeBadge={data.contents.typeBadge}
+              updatedAt={data.contents.updatedAt}
+              title={data.contents.title}
+              comment={data.contents.comment}
+              starRating={data.contents.starRating}
+              food={data.contents.food}
+              cafe={data.contents.cafe}
+              photoUrls={data.contents.photoUrls}
+              archiveAdditionalInfos={data.contents.archiveAdditionalInfos}
+            />
           </Box>
         </Popup>
       );

--- a/components/Organisms/Popup/PopupRouter.tsx
+++ b/components/Organisms/Popup/PopupRouter.tsx
@@ -1,5 +1,6 @@
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 
+import AlertArchiveDeletePopup from 'components/Organisms/Popup/AlertArchiveDeletePopup';
 import AlertCancelConfirmPopup from 'components/Organisms/Popup/AlertCancelConfirmPopup';
 import AlertSuccessPopup from 'components/Organisms/Popup/AlertConfirmPopup';
 import AlertLoginConfirmationPopup from 'components/Organisms/Popup/AlertLoginConfirmationPopup';
@@ -36,6 +37,8 @@ const PopupRouter = () => {
       return <ArchiveWirteConfirmPopup />;
     case POPUP_NAME.OVERFLOW_PICTURE:
       return <ArchivePictureOverflowPopup />;
+    case POPUP_NAME.ALERT_ARCHIVE_DELETE_CANCEL_CONFIRM:
+      return <AlertArchiveDeletePopup />;
     default:
       return null;
   }

--- a/constants/alertMessage.ts
+++ b/constants/alertMessage.ts
@@ -16,6 +16,10 @@ export const ALERT_MESSAGE = {
       code: 'ALT-003',
       message: '아카이브를 등록하시겠습니까?',
     },
+    ARCHIVE_DELETE_CONFIRM: {
+      code: 'ALT-004',
+      message: '삭제 하시겠습니까?',
+    },
     SAVED_SUCCESS: {
       code: 'ALT-009',
       message: '저장되었습니다.',

--- a/constants/popupName.ts
+++ b/constants/popupName.ts
@@ -7,4 +7,5 @@ export const POPUP_NAME = {
   ALERT_MOVE_MyARCHIVE_PAGE: 'AlertMoveMyArchivePage',
   ARCHIVE_WRITE_CONFIRM: 'ArchiveWirteConfirm',
   OVERFLOW_PICTURE: 'ArchivePictureOverflowPopup',
+  ALERT_ARCHIVE_DELETE_CANCEL_CONFIRM: 'AlertArchiveDeletePopup',
 };

--- a/pages/mypage/index.tsx
+++ b/pages/mypage/index.tsx
@@ -4,11 +4,16 @@ import { useSetRecoilState } from 'recoil';
 
 import LoginPage from 'components/Organisms/MyPage/LoginPage';
 import MyPageHome from 'components/Organisms/MyPage/MyPageHome';
+import { useResetMyArchiveListStateFunction } from 'states/myArchiveList';
 import { User } from 'states/user';
 import { useUserProps, UserProps } from 'utils/authentication/useUser';
 
 const MyPage: NextPage<UserProps> = ({ user }) => {
   const setUserFirst = useSetRecoilState(User);
+  const resetMyArchiveListState = useResetMyArchiveListStateFunction();
+  useEffect(() => {
+    resetMyArchiveListState();
+  }, [resetMyArchiveListState]);
 
   useEffect(() => {
     setUserFirst(user);

--- a/states/index.ts
+++ b/states/index.ts
@@ -1,7 +1,6 @@
 import AlertState from './alertState';
 import { archiveWriteState } from './archiveWirte';
 import { detailState } from './detail';
-import MyArchiveListState from './myArchiveList';
 import PopupNameState from './popupName';
 
 import { searchRequest } from 'states/search-result-request';
@@ -10,7 +9,6 @@ export {
   detailState,
   archiveWriteState,
   searchRequest,
-  MyArchiveListState,
   PopupNameState,
   AlertState,
 };

--- a/states/myArchiveDetail.ts
+++ b/states/myArchiveDetail.ts
@@ -1,15 +1,8 @@
 import { AxiosResponse } from 'axios';
-import {
-  atom,
-  GetRecoilValue,
-  selector,
-  useRecoilState,
-  useRecoilValue,
-} from 'recoil';
+import { atom, selector } from 'recoil';
 
 import customAxios from 'utils/hooks/customAxios';
 export interface MyArchiveDetailProps {
-  length: number;
   typeBadge: PresentationBadge;
   updatedAt: string;
   title: string;
@@ -20,12 +13,23 @@ export interface MyArchiveDetailProps {
   photoUrls: string[];
   archiveAdditionalInfos: ArchiveDetailLinkInfos[];
 }
+export interface MyArchiveDetailHeaderInfoProps {
+  title: string;
+  typeBadge: PresentationBadge;
+  updatedAt: string;
+  archiveAdditionalInfos: ArchiveDetailLinkInfos[];
+}
 
-export interface PresentationBadge {
+export interface MyArchiveDetailInfoProps {
+  starRating: number;
+  food: string;
+  cafe: string;
+}
+interface PresentationBadge {
   text: string;
   typeBadge: boolean;
 }
-export interface ArchiveDetailLinkInfos {
+interface ArchiveDetailLinkInfos {
   title: string;
   link: string;
 }
@@ -44,17 +48,6 @@ export const getMyArchiveDetail = async (archiveId: string) => {
 
   return data;
 };
-
-// export default atom<MyArchiveDetailProps>({
-//   key: 'MyArchiveDetailState',
-//   default: selector({
-//     key: 'MyArchiveDetailState/default',
-//     get: ({ get }) => {
-//       const archiveId = get(ClickedArchiveId);
-//       getMyArchiveDetail(archiveId);
-//     },
-//   }),
-// });
 
 export const myArchiveDetailInfoState = selector({
   key: 'myArchiveDetailInfoState',

--- a/states/myArchiveList.ts
+++ b/states/myArchiveList.ts
@@ -1,5 +1,5 @@
 import { AxiosResponse } from 'axios';
-import { atom, selector } from 'recoil';
+import { atom, selector, useRecoilCallback } from 'recoil';
 
 import customAxios from 'utils/hooks/customAxios';
 
@@ -47,7 +47,13 @@ export const getList = async () => {
   return data;
 };
 
-export default atom({
+export const useResetMyArchiveListStateFunction = () =>
+  useRecoilCallback(({ set }) => async () => {
+    const listStateData = await getList();
+    set(myArchiveListState, listStateData);
+  });
+
+export const myArchiveListState = atom({
   key: 'MyArchiveListState',
   default: selector({
     key: 'MyArchiveListState/default',


### PR DESCRIPTION
* update:코멘트 영역-스크롤 표시 수정, html 가능하게 수정

* delete: 필요없는 코드 삭제

* 🎨 update: 아카이브 디테일 컴포넌트 분리, 인터페이스 추가

* update: 선 수정

* update: 장소 데이터 유무 화면 처리

* add: 별점 그리기 기능 추가

* add: 사진 아이템 갯수에 보여주도록 처리

* 🔨 add : 마이아카이브리스트 페이지 재진입시 state 업데이트

* add : 수정버튼 클릭시 router push 되도록

* 🔨 add: 삭제버튼 클릭시 나올 alert 창 설정

* 🔨 update: 마이아카이브 카운팅 추가

* add: 마이아카이브 카운팅 0개일때 안나오게 처리

* update:아카이브 리스트 갯수 표시 할때 무한호출 에러 수정 및 코드 재배치

* delete: 콘솔로그 삭제

* update: archiveId 관련 응답값 변경되어 수정

* delete: 안쓰는 코드 정리

* delete: 안쓰는 코드 삭제

* add: 삭제 기능 진행중 ..

* add: 아카이브 수정기능 진행중..

* update: 안쓰는 임포트 삭제

* delete: 안쓰는 코드 삭제

* delete: 안쓰는 코드 삭제

## **📄 PR 카테고리**

- ⬜️ 리팩토링
- ⬜️ 화면 개발 ( 추가, 수정, 삭제 )
- ✅ QA 및 버그 수정
- ⬜️ 기타 ( 버전 업데이트 등 )

## **⌨️ 변경점**

## **🤦🏻 고민한 부분**

## **🙋🏼‍♀️ 추가 논의가 필요한 부분**

## **✋ 추가 코멘트**
