### PR TITLE
검색 페이지 수정사항

### DIFF
--- a/components/Atoms/Input.tsx
+++ b/components/Atoms/Input.tsx
@@ -37,6 +37,7 @@ const Input = styled.input<
   ${flexbox}
   ${background}
   width: 100%;
+  appearance: none;
 `;
 
 export default Input;

--- a/components/Organisms/Common/SearchHeaderBar.tsx
+++ b/components/Organisms/Common/SearchHeaderBar.tsx
@@ -77,10 +77,12 @@ export default function SearchHeaderBar() {
       if (typeof router.query.keyword === 'string') {
         setKeyword(router.query.keyword);
       }
-    } else {
+    }
+    // 검색 페이지 진입시 Input값 제거
+    else if (router.pathname === '/search') {
       setKeyword('');
     }
-  }, [router.query.keyword]);
+  }, [router.pathname, router.query.keyword]);
 
   return (
     <>

--- a/components/Organisms/Common/SearchHeaderBar.tsx
+++ b/components/Organisms/Common/SearchHeaderBar.tsx
@@ -126,13 +126,20 @@ export default function SearchHeaderBar() {
                 padding="0px 45px 0px 15px"
                 height="40px"
                 fontSize="13px"
+                backgroundColor={theme.colors.white}
                 border={`1px solid ${theme.colors.grayDD}`}
+                borderRadius="0"
                 value={keyword}
                 placeholder="검색어를 입력해주세요"
                 onChange={onChange}
                 onKeyPress={handleOnKeyPress}
                 type="search"
                 ref={inputRef}
+                css={css`
+                  appearance: none;
+                  -webkit-appearance: none;
+                  -moz-appearance: none;
+                `}
               />
               <Button
                 position="absolute"

--- a/components/Organisms/Common/SearchHeaderBar.tsx
+++ b/components/Organisms/Common/SearchHeaderBar.tsx
@@ -135,11 +135,6 @@ export default function SearchHeaderBar() {
                 onKeyPress={handleOnKeyPress}
                 type="search"
                 ref={inputRef}
-                css={css`
-                  appearance: none;
-                  -webkit-appearance: none;
-                  -moz-appearance: none;
-                `}
               />
               <Button
                 position="absolute"

--- a/components/Organisms/Common/SearchHeaderBar.tsx
+++ b/components/Organisms/Common/SearchHeaderBar.tsx
@@ -77,9 +77,8 @@ export default function SearchHeaderBar() {
       if (typeof router.query.keyword === 'string') {
         setKeyword(router.query.keyword);
       }
-    }
-    // 검색 페이지 진입시 Input값 제거
-    else if (router.pathname === '/search') {
+    } else if (router.pathname === '/search') {
+      /** 검색 페이지 진입시 Input값 제거 */
       setKeyword('');
     }
   }, [router.pathname, router.query.keyword]);

--- a/components/Organisms/Search/RecentSearch.tsx
+++ b/components/Organisms/Search/RecentSearch.tsx
@@ -32,6 +32,7 @@ export default function RecentSearch() {
         최근 검색어
       </Box>
       <Box
+        display={localStorageKeywords?.length > 0 ? '' : 'none'}
         position="absolute"
         top="0px"
         right="15px"

--- a/components/Organisms/Search/SearchTitle.tsx
+++ b/components/Organisms/Search/SearchTitle.tsx
@@ -41,6 +41,7 @@ export default function SearchTitle({
                   <Button
                     textAlign="left"
                     width="100%"
+                    fontSize="15px"
                     css={css`
                       white-space: nowrap;
                       overflow: hidden;


### PR DESCRIPTION
## **📄 PR 카테고리**

- ✅ 리팩토링
- ⬜️ 화면 개발 ( 추가, 수정, 삭제 )
- ✅ QA 및 버그 수정
- ⬜️ 기타 ( 버전 업데이트 등 )

## **⌨️ 변경점**
1. 아이폰 > input background 회색표시 수정

2. 자동완성 폰트 수정 (15px로)

3. 아이폰 Input type search 강제 돋보기 아이콘 생성 없애기
input 컴포넌트에 공통으로 css '  appearance: none;' 추가

4. 검색어 없을시 전체삭제 안보이기
<img width="426" alt="스크린샷 2022-12-01 오후 10 02 23" src="https://user-images.githubusercontent.com/38105502/205059700-2df36d23-272e-4674-825a-2557ba3daa1f.png">

5. 인풋 검색어 남는 이슈 수정
 
## **🤦🏻 고민한 부분**

## **🙋🏼‍♀️ 추가 논의가 필요한 부분**

## **✋ 추가 코멘트**
연관검색어가 간간히 뜨는 이슈가 있습니다. 
이 부분은 노션에 이슈 관리로 넘길 예정입니다.
https://kimseyoung.notion.site/Input-497ce25ee07041ed85a709a2ee9f7682
