### PR TITLE
Feat: archive 비로그인 시 보이는 페이지

### DIFF
--- a/components/Organisms/Archive/ArchiveLogin.tsx
+++ b/components/Organisms/Archive/ArchiveLogin.tsx
@@ -1,0 +1,43 @@
+import { useRouter } from 'next/router';
+
+import Alert from 'assets/error/Alert';
+import { Box, Button } from 'components/Atoms';
+import theme from 'styles/theme';
+
+export default function ArchiveLogin() {
+  const router = useRouter();
+  return (
+    <Box
+      position="absolute"
+      top="calc(50% - 110px)"
+      left="0px"
+      width="100%"
+      textAlign="center"
+      fontSize="0"
+    >
+      <Alert width="40px" height="40px" />
+      <Box
+        margin="20px 0px 40px"
+        fontSize="13px"
+        lineHeight="20px"
+        fontWeight="500"
+      >
+        로그인 후 이용해주세요.
+      </Box>
+      <Button
+        display="inline-block"
+        height="40px"
+        width="130px"
+        color={theme.colors.white}
+        fontSize="13px"
+        lineHeight="40px"
+        background={theme.colors.black}
+        onClick={() => {
+          router.push('/mypage');
+        }}
+      >
+        로그인 하기
+      </Button>
+    </Box>
+  );
+}

--- a/pages/archive/index.tsx
+++ b/pages/archive/index.tsx
@@ -1,28 +1,15 @@
+import { NextPage } from 'next';
 import { useRouter } from 'next/router';
-import { useEffect } from 'react';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import { Box } from 'components/Atoms';
 import ArchiveHome from 'components/Organisms/Archive/ArchiveHome';
-import { ALERT_MESSAGE } from 'constants/alertMessage';
-import { POPUP_NAME } from 'constants/popupName';
-import { AlertState, PopupNameState } from 'states';
-import { User } from 'states/user';
+import ArchiveLogin from 'components/Organisms/Archive/ArchiveLogin';
 import theme from 'styles/theme';
+import { UserProps, useUserProps } from 'utils/authentication/useUser';
 import { useInitHeader } from 'utils/hooks/useInitHeader';
 
-export default function Archive() {
+const Archive: NextPage<UserProps> = ({ user }) => {
   const router = useRouter();
-  const loginState = useRecoilValue(User);
-  const setAlertState = useSetRecoilState(AlertState);
-  const setPopupName = useSetRecoilState(PopupNameState);
-
-  useEffect(() => {
-    if (loginState.isLogin) {
-      setAlertState(ALERT_MESSAGE.ALERT.LOGIN_CONFIRMATION);
-      setPopupName(POPUP_NAME.ALERT_LOGIN_CONFIRMATION);
-    }
-  }, [loginState, loginState.isLogin, router, setAlertState, setPopupName]);
 
   useInitHeader({
     headerLeft: 'default',
@@ -31,10 +18,16 @@ export default function Archive() {
     headerLeftAction: () => router.push('/mypage'),
   });
 
+  if (!user.isLogin) {
+    return <ArchiveLogin />;
+  }
   return (
     <Box padding="0 15px" background={theme.colors.white}>
       <ArchiveHome />
       <Box height="60px" />
     </Box>
   );
-}
+};
+
+export const getServerSideProps = useUserProps;
+export default Archive;


### PR DESCRIPTION
## **📄 PR 카테고리**

- ⬜️ 리팩토링
- ⬜️ 화면 개발 ( 추가, 수정, 삭제 )
- ✅ QA 및 버그 수정
- ⬜️ 기타 ( 버전 업데이트 등 )

## **⌨️ 변경점**

- 비로그인시 보이는 페이지 변경

<img width="335" alt="스크린샷 2022-12-01 오후 9 59 04" src="https://user-images.githubusercontent.com/48988891/205059002-51c7b0ba-7725-4ad3-9a09-913c3c1435d3.png">

## **🤦🏻 고민한 부분**

알림창으로 비로그인 임을 보여주었는데, 다른 컴포넌트로 보여주는 것이 사용자 입장에서 로그인 상태를 명확하게 인지할 수 있을 것 같아 변경했습니다.
