### PR TITLE
픽 페이지 로그인 이슈 수정

### DIFF
--- a/components/Organisms/Pick/PickTitle.tsx
+++ b/components/Organisms/Pick/PickTitle.tsx
@@ -1,11 +1,13 @@
-import { useRecoilValue } from 'recoil';
+import { useRecoilValueLoadable } from 'recoil';
 
 import { Box, Span } from 'components/Atoms';
 import { pickState } from 'states/pick';
 import theme from 'styles/theme';
 
 export default function PickTitle() {
-  const pickCount = useRecoilValue(pickState);
+  const pickCount = useRecoilValueLoadable(pickState);
+
+  if (pickCount.state !== 'hasValue') return <></>;
 
   return (
     <>
@@ -15,13 +17,13 @@ export default function PickTitle() {
         lineHeight="27px"
         fontWeight="500"
       >
-        {pickCount.count !== 0 ? (
+        {pickCount.contents.count !== 0 ? (
           <Span
             display="inline-block"
             marginRight="3px"
             color={theme.colors.orange}
           >
-            {pickCount.count}
+            {pickCount.contents.count}
           </Span>
         ) : (
           ''

--- a/pages/pick/index.tsx
+++ b/pages/pick/index.tsx
@@ -22,9 +22,8 @@ const Pick: NextPage<UserProps> = ({ user }) => {
 
   if (user.isLogin) {
     return <MyPickPage />;
-  } else {
-    return <PickLogin />;
   }
+  return <PickLogin />;
 };
 
 export const getServerSideProps = useUserProps;


### PR DESCRIPTION
## **📄 PR 카테고리**

- ⬜️ 리팩토링
- ⬜️ 화면 개발 ( 추가, 수정, 삭제 )
- ✅ QA 및 버그 수정
- ⬜️ 기타 ( 버전 업데이트 등 )

## **⌨️ 변경점**
### **상황 플로우**
미 로그인 상태로 픽 페이지 이동 > 로그인 하기 버튼 클릭 > 로그인

### **기대 값**
로그인 성공 시 픽 페이지로 이동

### **결과 값**
픽 페이지로 이동은 하지만 페이지가 렌더링이 되지 않는 이슈

### **기대값이 나올 수 있게 수정**
useRecoilValue를 useRecoilValueLoadable로 수정

## **🤦🏻 고민한 부분**

## **🙋🏼‍♀️ 추가 논의가 필요한 부분**
로그인이 된 상태에서 픽 페이지를 새로고침 시 404에러가 뜨는 이슈가 있습니다.
네트워크에서는 에러가 노출되지 않아서 뭐가 문제인지 모르겠습니다.

### 콘솔 에러
<img width="467" alt="스크린샷 2022-12-09 오후 9 03 49" src="https://user-images.githubusercontent.com/38105502/206698539-00d6c87d-74a1-4e48-9945-c2653841a0f0.png">
<img width="1439" alt="스크린샷 2022-12-09 오후 9 10 48" src="https://user-images.githubusercontent.com/38105502/206699803-9629c2f2-2d77-4133-bf83-193ee3d3eb09.png">


### 네트워크
<img width="899" alt="스크린샷 2022-12-09 오후 9 05 24" src="https://user-images.githubusercontent.com/38105502/206698831-2e57c8e7-cfda-4c7c-8e93-127b60208cb5.png">


## **✋ 추가 코멘트**

