### PR TITLE
웹뷰 작업

### DIFF
--- a/components/Atoms/Shadow.tsx
+++ b/components/Atoms/Shadow.tsx
@@ -10,8 +10,10 @@ export default styled.div<PopupProps>`
   position: fixed;
   top: 0;
   width: 100%;
+  max-width: 480px;
   height: 100vh;
-  left: 0;
+  left: 50%;
+  transform: translateX(-50%);
   background-color: rgb(0, 0, 0, 0.7);
   z-index: ${Z_INDEX.LOADING};
 `;

--- a/components/Molecules/CarouselDim.tsx
+++ b/components/Molecules/CarouselDim.tsx
@@ -4,11 +4,12 @@ import Box from 'components/Atoms/Box';
 
 const CarouselDim = ({ height }: { height: string }) => (
   <Box
-    width="100vw"
     height="230px"
     top="270px"
     opacity={0.4}
     position="absolute"
+    left="0"
+    right="0"
     css={css`
       top: calc(${height} - 230px);
       background-image: linear-gradient(

--- a/components/Molecules/CarouselItem.tsx
+++ b/components/Molecules/CarouselItem.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image';
 
 import Box from 'components/Atoms/Box';
 import CarouselDim from 'components/Molecules/CarouselDim';
+import theme from 'styles/theme';
 import useIntersectionObserver from 'utils/hooks/useIntersectionObserver';
 
 export default function CarouselItem({
@@ -42,6 +43,7 @@ export default function CarouselItem({
         scroll-snap-align: start;
       `}
       width={width}
+      maxWidth={theme.view.webView}
       height={height}
       position="relative"
       ref={setTarget}

--- a/components/Molecules/FloatingButton.tsx
+++ b/components/Molecules/FloatingButton.tsx
@@ -3,23 +3,34 @@ import router from 'next/router';
 
 import { Folder } from 'assets/mypage/Folder';
 import { Box } from 'components/Atoms';
+import theme from 'styles/theme';
 
 export default function FloatingButton() {
   return (
     <Box
-      display="block"
-      flex-wrap="nowrap"
-      overflow="initial"
       position="fixed"
       bottom="80px"
-      marginBottom="var(--platformBottomArea)"
-      right="15px"
+      left="0"
+      right="0"
+      margin="0 auto"
+      maxWidth={theme.view.webView}
+      zIndex="100"
       onClick={() => router.push('/archive')}
     >
-      <Box position="absolute" zIndex="1000">
+      <Box
+        position="absolute"
+        bottom="0"
+        right="15px"
+        width="50px"
+        height="50px"
+        zIndex="100"
+      >
         <Folder />
       </Box>
       <Box
+        position="absolute"
+        bottom="0"
+        right="15px"
         width="50px"
         height="50px"
         borderRadius="50%"

--- a/components/Molecules/InfiniteCarousel.tsx
+++ b/components/Molecules/InfiniteCarousel.tsx
@@ -90,6 +90,7 @@ export default function InfiniteCarousel({
       <Box
         width={width}
         height={height}
+        maxWidth={theme.view.webView}
         overflowY="hidden"
         overflowX="scroll"
         css={css`

--- a/components/Organisms/Common/BottomTabNavigator.tsx
+++ b/components/Organisms/Common/BottomTabNavigator.tsx
@@ -4,6 +4,7 @@ import { useRecoilValue } from 'recoil';
 import { Box, FlexBox } from 'components/Atoms';
 import { Z_INDEX } from 'constants/common';
 import { headerState } from 'states/common';
+import theme from 'styles/theme';
 import useRefUtils from 'utils/hooks/useRefUtils';
 
 interface BottomTabItemProps {
@@ -53,6 +54,7 @@ export default function BottomTabNavigator({
           backgroundColor="#f8f8f8"
           bottom="0px"
           width="100%"
+          maxWidth={theme.view.webView}
           position="fixed"
           ref={ref}
         >

--- a/components/Organisms/Common/Container.tsx
+++ b/components/Organisms/Common/Container.tsx
@@ -19,6 +19,12 @@ export default function Container({ children }: { children: ReactNode }) {
 
   return (
     <Box
+      position="relative"
+      width="100%"
+      maxWidth={theme.view.webView}
+      minHeight="100%"
+      margin="0 auto"
+      boxShadow="0 0 20px rgb(0 0 0 / 5%);"
       style={
         modalOut || PopupState
           ? { position: 'fixed', inset: '0', touchAction: 'none' }

--- a/components/Organisms/Common/HeaderBar.tsx
+++ b/components/Organisms/Common/HeaderBar.tsx
@@ -80,6 +80,7 @@ function HeaderBar() {
             `}
             top="0px"
             width="100%"
+            maxWidth={theme.view.webView}
             background={theme.colors.white}
             zIndex={Z_INDEX.SKY}
           >
@@ -169,6 +170,7 @@ function HeaderBar() {
           `}
           top="0px"
           width="100%"
+          maxWidth={theme.view.webView}
           backgroundColor="rgba(0,0,0,0)"
           zIndex={Z_INDEX.SKY}
         >

--- a/components/Organisms/Common/SearchHeaderBar.tsx
+++ b/components/Organisms/Common/SearchHeaderBar.tsx
@@ -96,6 +96,7 @@ export default function SearchHeaderBar() {
             `}
             top="0px"
             width="100%"
+            maxWidth={theme.view.webView}
             background={theme.colors.white}
             zIndex={Z_INDEX.SKY}
           >

--- a/components/Organisms/Detail/ExhibitionImagesSection.tsx
+++ b/components/Organisms/Detail/ExhibitionImagesSection.tsx
@@ -4,6 +4,7 @@ import { useRecoilValue, useRecoilValueLoadable } from 'recoil';
 import noImage from 'assets/common/no_image_375x500.png';
 import { Box } from 'components/Atoms';
 import { summaryState } from 'states/detail';
+import theme from 'styles/theme';
 
 export default function ExhibitionImagesSection() {
   const data = useRecoilValue(summaryState);
@@ -16,6 +17,7 @@ export default function ExhibitionImagesSection() {
       width="100%"
       height="100%"
       maxHeight="450px"
+      maxWidth={theme.view.webView}
     >
       <Image
         src={detailImageUrl ? detailImageUrl : noImage}

--- a/components/Organisms/Detail/Navigator.tsx
+++ b/components/Organisms/Detail/Navigator.tsx
@@ -72,6 +72,7 @@ export default function Navigator() {
       bottom="0px"
       position="fixed"
       padding="0 15px"
+      maxWidth={theme.view.webView}
     >
       <FlexBox height="60px" alignItems="center" justifyContent="space-between">
         <FlexBox>

--- a/components/Organisms/Home/Module/SwipeItem/UnbalencedSwiper.tsx
+++ b/components/Organisms/Home/Module/SwipeItem/UnbalencedSwiper.tsx
@@ -3,6 +3,7 @@ import { css } from '@emotion/react';
 import { Box } from 'components/Atoms';
 import MainSwipeImage from 'components/Organisms/Home/Module/SwipeItem/MainSwipeImage';
 import SubSwipeImage from 'components/Organisms/Home/Module/SwipeItem/SubSwipeImage';
+import theme from 'styles/theme';
 
 export default function UnbalencedSwiper({
   thumbnailPhotoUrl,
@@ -15,6 +16,7 @@ export default function UnbalencedSwiper({
     <Box
       marginTop="60px"
       width="100vw"
+      maxWidth={theme.view.webView}
       height="420px"
       overflowY="hidden"
       overflowX="scroll"

--- a/components/Organisms/Modal/ModalBox.tsx
+++ b/components/Organisms/Modal/ModalBox.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/react';
 import { useResetRecoilState } from 'recoil';
 
 import { Box } from 'components/Atoms';
@@ -15,24 +16,32 @@ export default function ModalBox({ children }: { children: React.ReactNode }) {
       <Box
         position="fixed"
         top="0"
-        left="0"
+        left="50%"
         background={theme.colors.black}
         opacity="0.7"
         width="100vw"
         height="100vh"
+        maxWidth={theme.view.webView}
         zIndex={Z_INDEX.MODAL}
+        css={css`
+          transform: translateX(-50%);
+        `}
       />
       <Box
         position="fixed"
         top="0"
-        left="0"
+        left="50%"
         width="100vw"
         height="100%"
+        maxWidth={theme.view.webView}
         onClick={() => {
           offModal();
           resetFilter();
         }}
         zIndex={Z_INDEX.MODAL}
+        css={css`
+          transform: translateX(-50%);
+        `}
       >
         <Box onClick={(e) => e.stopPropagation()}>{children}</Box>
       </Box>

--- a/components/Organisms/MyPage/Archive/ListSection.tsx
+++ b/components/Organisms/MyPage/Archive/ListSection.tsx
@@ -6,7 +6,7 @@ import { MyArchivePageContents } from 'states/myArchiveList';
 export default function ListSection(data: any) {
   return (
     <>
-      <Box marginBottom="60px">
+      <Box paddingBottom="60px">
         {data?.contents?.contents?.map(
           (content: MyArchivePageContents, index: number) => (
             <ListCard key={content?.api ?? index} content={content} />

--- a/components/Organisms/MyPage/Update/UpdateButton.tsx
+++ b/components/Organisms/MyPage/Update/UpdateButton.tsx
@@ -84,7 +84,6 @@ export default function UpdateButton() {
   return (
     <Box
       marginTop="60px"
-      marginBottom="80px"
       backgroundColor={theme.colors.black}
       color={theme.colors.white}
       paddingY="15px"

--- a/components/Organisms/MyPage/Update/UpdateHome.tsx
+++ b/components/Organisms/MyPage/Update/UpdateHome.tsx
@@ -46,7 +46,7 @@ export default function UpdateHome({
   );
 
   return (
-    <Box paddingX="15px">
+    <Box padding="0px 15px 40px">
       <UpdateInputSet type="name" labelText="닉네임" />
       <UpdateInputSet type="phoneNumber" labelText="휴대폰번호" />
       <UpdateInputSet type="birthDay" labelText="생일" />

--- a/components/Organisms/Pick/MyPickPage.tsx
+++ b/components/Organisms/Pick/MyPickPage.tsx
@@ -15,11 +15,7 @@ export default function MyPickPage() {
   return (
     <>
       <PickTitle />
-      <FlexBox
-        padding="0px 12.5px !important"
-        flexWrap="wrap"
-        marginBottom="120px"
-      >
+      <FlexBox padding="0px 12.5px 120px !important" flexWrap="wrap">
         <PickSection />
       </FlexBox>
     </>

--- a/components/Organisms/Search/SearchTitle.tsx
+++ b/components/Organisms/Search/SearchTitle.tsx
@@ -33,6 +33,8 @@ export default function SearchTitle({
           position="fixed"
           top="52px"
           padding="12px 15px"
+          maxWidth={theme.view.webView}
+          margin="0 auto"
         >
           <Box>
             {keyItems.map((search) => (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -20,7 +20,7 @@ const Home: NextPage = () => {
   switch (data.state) {
     case 'hasValue':
       return (
-        <Box marginBottom="120px">
+        <Box paddingBottom="120px">
           {data.contents.map(({ moduleName, data }, index) => (
             <ModuleResolver
               moduleName={moduleName}

--- a/pages/list/index.tsx
+++ b/pages/list/index.tsx
@@ -52,7 +52,7 @@ export default function List() {
           <ListFilter />
         </FlexBox>
       </Box>
-      <Layout padding="0px 15px !important" marginBottom="120px">
+      <Layout padding="0px 15px 80px !important">
         <ListSection />
       </Layout>
     </>

--- a/pages/search/result.tsx
+++ b/pages/search/result.tsx
@@ -10,7 +10,7 @@ export default function SearchResult() {
   });
 
   return (
-    <Layout padding="0px 15px !important" margin="20px 0px 120px">
+    <Layout padding="20px 15px 60px !important">
       <SearchResultSection />
     </Layout>
   );

--- a/styles/GlobalStyles.tsx
+++ b/styles/GlobalStyles.tsx
@@ -12,6 +12,12 @@ export default function GlobalStyles() {
   return (
     <Global
       styles={css`
+        #__next,
+        body,
+        html {
+          width: 100%;
+          height: 100%;
+        }
         body {
           font-family: -apple-system, SpoqaHanSansNeo, sans-serif !important;
         }

--- a/styles/theme/index.ts
+++ b/styles/theme/index.ts
@@ -15,6 +15,9 @@ const theme = {
     gray33: '#333',
     grayAA: '#aaaaaa',
   },
+  view: {
+    webView: '480px',
+  },
 };
 
 export type Theme = typeof theme;


### PR DESCRIPTION
## **📄 PR 카테고리**

- ⬜️ 리팩토링
- ✅  화면 개발 ( 추가, 수정, 삭제 )
- ⬜️ QA 및 버그 수정
- ⬜️ 기타 ( 버전 업데이트 등 )

## **⌨️ 변경점**
### **웹 뷰 max-width : 480px** 
<img width="1440" alt="스크린샷 2022-12-09 오후 9 42 08" src="https://user-images.githubusercontent.com/38105502/206704883-a0715123-88f4-4b2b-a55b-6b3d302d7e02.png">


### **1. 변경될 가능성이 있어서 webView로 생성**
<img width="392" alt="스크린샷 2022-12-09 오후 9 40 03" src="https://user-images.githubusercontent.com/38105502/206704548-6bfa6eb3-4536-42b4-8ad4-bcca64b5691c.png">

### **2. 최상단 div에 웹 뷰 관련css 추가 - Container.tsx**
<img width="552" alt="스크린샷 2022-12-09 오후 9 43 49" src="https://user-images.githubusercontent.com/38105502/206705151-7b861795-56bc-4149-a0b7-a855372c1f1d.png">

### **3. position아 fixed인 레이아웃은 각각 max-width & margin: 0 auto 추가**

### **4. html / body / id="__next" 에다 height width 100% 추가**
<img width="494" alt="스크린샷 2022-12-09 오후 9 51 17" src="https://user-images.githubusercontent.com/38105502/206706514-852540dd-2eb1-4464-b818-e482b03314c4.png">


## **🤦🏻 고민한 부분**
변경점 4번관련하여 논의가 필요한 것 같습니다!
height 혹은 width를 100%로 잡으면 부모를 따라가게 되는데, 
id="__next"에 height에 100%를 주지 않으면 화면 높이가 전체로 잡히지 않는 이슈가 있습니다. 

(이슈 사진)
<img width="1419" alt="스크린샷 2022-12-09 오후 9 54 37" src="https://user-images.githubusercontent.com/38105502/206707129-142ce61d-61a2-4e38-849f-db91e4ce0a5f.png">

(기대 결과 사진)
<img width="1439" alt="스크린샷 2022-12-09 오후 9 55 36" src="https://user-images.githubusercontent.com/38105502/206707312-df7831b7-3398-4f6a-b613-1c77ec0f1955.png">

하지만 id="__next"에 강제로 height / width값을 잡아도 되는지 이야기 해봐야 할 것 같아요.

* 이 방법 말고 height를 100vw 또는 100vh로 지정을 해봤는데, 스크롤이 길어지는 페이지에서는 box-shadow가 잘리는 이슈가 있습니다.
(이슈 사진)
<img width="1440" alt="스크린샷 2022-12-09 오후 9 57 59" src="https://user-images.githubusercontent.com/38105502/206707742-360da259-7971-4894-a7a9-633efdacc980.png">


## **🙋🏼‍♀️ 추가 논의가 필요한 부분**

## **✋ 추가 코멘트**
