### PR TITLE
 검색페이지 자동완성 노출 이슈 수정

### DIFF
--- a/components/Organisms/Common/SearchHeaderBar.tsx
+++ b/components/Organisms/Common/SearchHeaderBar.tsx
@@ -29,8 +29,10 @@ export default function SearchHeaderBar() {
   const [keyword, setKeyword] = useState('');
   const [keyItems, setKeyItems] = useState<AutoContents[]>([]);
   const inputRef = useRef<any>();
+  const [checkDebounce, setCheckDebounce] = useState(true);
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setCheckDebounce(true);
     setKeyword(e.target.value);
     debounceOnChange();
     if (!inputRef?.current?.value) {
@@ -41,6 +43,7 @@ export default function SearchHeaderBar() {
   const handleOnClick = () => {
     if (keyword) {
       makeLocalStorageKeywords(keyword);
+      setCheckDebounce(false);
       router.push({
         pathname: '/search/result',
         query: { keyword },
@@ -72,7 +75,6 @@ export default function SearchHeaderBar() {
   };
 
   useEffect(() => {
-    setKeyItems([]);
     if (router?.query?.keyword) {
       if (typeof router.query.keyword === 'string') {
         setKeyword(router.query.keyword);
@@ -152,7 +154,11 @@ export default function SearchHeaderBar() {
               </Button>
             </Box>
           </Box>
-          <SearchTitle keyItems={keyItems} keyword={keyword} />
+          <SearchTitle
+            keyItems={keyItems}
+            keyword={keyword}
+            checkDebounce={checkDebounce}
+          />
         </Box>
       ) : (
         ''

--- a/components/Organisms/Search/SearchTitle.tsx
+++ b/components/Organisms/Search/SearchTitle.tsx
@@ -8,6 +8,7 @@ import useSetLocalstorageKeywords from 'utils/hooks/useSetLocalstorageKeywords';
 export default function SearchTitle({
   keyItems,
   keyword,
+  checkDebounce,
 }: {
   keyItems: {
     id: number;
@@ -17,13 +18,14 @@ export default function SearchTitle({
     title: string;
   }[];
   keyword: string;
+  checkDebounce: boolean;
 }) {
   const router = useRouter();
   const { makeLocalStorageKeywords } = useSetLocalstorageKeywords();
 
   return (
     <>
-      {keyItems?.length > 0 && keyword && (
+      {keyItems?.length > 0 && keyword && checkDebounce && (
         <Box
           zIndex="3"
           width="100%"


### PR DESCRIPTION
## **📄 PR 카테고리**

- ⬜️ 리팩토링
- ⬜️ 화면 개발 ( 추가, 수정, 삭제 )
- ✅ QA 및 버그 수정
- ⬜️ 기타 ( 버전 업데이트 등 )

## **⌨️ 변경점**

## 이슈사항
https://kimseyoung.notion.site/Input-497ce25ee07041ed85a709a2ee9f7682

## 이슈 이유
빠르게 검색어를 입력 한 후 검색 결과 페이지로 이동을 하면 (검색 버튼을 누르거나 엔터키를 눌렀을 때),
debounceOnChange() 함수가 딜레이 되면서 호출 (setTimeout을 사용하여 딜레이가 된 것으로 판단)

[관련 함수]
<img width="458" alt="스크린샷 2022-12-13 오전 11 19 20" src="https://user-images.githubusercontent.com/38105502/207210054-c3021852-1696-471f-b56b-4241203ff889.png">

## 해결 방법
checkDebounce라는 하나의 변수를 만들어 자동완성의 유무를 판단

## **🤦🏻 고민한 부분**
checkDebounce라는 새로운 상태값말고 다른 방법으로 자동완성 유무를 판단할 수 있는 방법이 있을까요?

## **🙋🏼‍♀️ 추가 논의가 필요한 부분**

## **✋ 추가 코멘트**
