### PR TITLE
네비게이션 과 url 일치시 폰드 500

### DIFF
--- a/components/Organisms/Common/BottomTabNavigator.tsx
+++ b/components/Organisms/Common/BottomTabNavigator.tsx
@@ -27,7 +27,13 @@ function BottomTabItem({ data }: { data: BottomTabItemProps }) {
       onClick={() => router.push(data.path?.[0] ?? '')}
     >
       <Box marginBottom="2px">{isSelected ? data.selectedIcon : data.icon}</Box>
-      <Box fontSize="9px">{data.pathName}</Box>
+      <Box fontSize="9px">
+        {isSelected ? (
+          <Box fontWeight={500}>{data.pathName}</Box>
+        ) : (
+          data.pathName
+        )}
+      </Box>
     </FlexBox>
   );
 }


### PR DESCRIPTION
## **📄 PR 카테고리**

- ⬜️ 리팩토링
- ⬜️ 화면 개발 ( 추가, 수정, 삭제 )
- ✅ QA 및 버그 수정
- ⬜️ 기타 ( 버전 업데이트 등 )

## **⌨️ 변경점**

홈	WEB,dev	하단 네비게이션 활성 시	활성 시 font-weight : 500	반영되지 않음. 제플린 참고 https://zpl.io/L48lJPJ

| 기존화면 | 수정화면 |
| -------- | -------- |
| <img width="334" alt="image" src="https://user-images.githubusercontent.com/48988891/211132305-841f3e1b-c350-4416-9016-38dd9f84ed8f.png"> | <img width="336" alt="image" src="https://user-images.githubusercontent.com/48988891/211132324-4830e98e-ea70-424c-887b-fec860c95384.png"> |




## **🤦🏻 고민한 부분**

## **🙋🏼‍♀️ 추가 논의가 필요한 부분**

## **✋ 추가 코멘트**
