### PR TITLE
[QA] 검색페이지 많이 픽한 문화생활 디자인 수정사항 반영

### DIFF
--- a/components/Organisms/Search/PickRanking.tsx
+++ b/components/Organisms/Search/PickRanking.tsx
@@ -21,7 +21,7 @@ export default function PickRanking() {
         lineHeight="22px"
         fontWeight="500"
       >
-        많이 PICK한 문화생활
+        Monthly Best Pick
       </Box>
       <SwipeItem contents={pickMost.contents.contents} />
     </>

--- a/components/Organisms/Search/SwipeItem/SwipeItemImage.tsx
+++ b/components/Organisms/Search/SwipeItem/SwipeItemImage.tsx
@@ -45,11 +45,14 @@ export default function SwipeItemImage({ presentationImage }: ImagePorps) {
             <Box
               position="absolute"
               top="calc(50% - 16px)"
-              left="calc(50% - 30px)"
+              left="50%"
               color={theme.colors.white}
               fontSize="22px"
               lineHeight="32px"
               zIndex="2"
+              css={css`
+                transform: translateX(-50%);
+              `}
             >
               {presentationImage.backgroundText}
             </Box>


### PR DESCRIPTION
## **📄 PR 카테고리**

- ⬜️ 리팩토링
- ⬜️ 화면 개발 ( 추가, 수정, 삭제 )
- ✅ QA 및 버그 수정
- ⬜️ 기타 ( 버전 업데이트 등 )

## **⌨️ 변경점**
### 1. 많이 픽한 문화생활 타이틀 변경
| 기존화면 | 수정화면 |
| -------- | -------- |
| <img width="507" alt="스크린샷 2023-02-07 오전 9 23 19" src="https://user-images.githubusercontent.com/38105502/217116891-3e55bea6-cf95-4076-b300-c6be240f1572.png"> | <img width="496" alt="스크린샷 2023-02-07 오전 9 23 49" src="https://user-images.githubusercontent.com/38105502/217116946-63f9b464-298a-476f-96f1-f78ad455dbb7.png"> |

### 2. 종료 타이틀 중앙 정렬
| 기존화면 | 수정화면 |
| -------- | -------- |
| <img width="197" alt="스크린샷 2023-02-07 오전 9 26 53" src="https://user-images.githubusercontent.com/38105502/217117378-c7743d5c-a1f7-4176-a87f-fbc0361ef2c4.png"> | <img width="199" alt="스크린샷 2023-02-07 오전 9 26 19" src="https://user-images.githubusercontent.com/38105502/217117368-84874651-e9f5-443e-80c5-b5614e12d433.png"> |

## **🤦🏻 고민한 부분**

## **🙋🏼‍♀️ 추가 논의가 필요한 부분**

## **✋ 추가 코멘트**
