### PR TITLE
[Fix] 검색 완료 페이지 스크롤 시 input focus 해제

### DIFF
--- a/components/Organisms/Common/SearchHeaderBar.tsx
+++ b/components/Organisms/Common/SearchHeaderBar.tsx
@@ -74,6 +74,21 @@ export default function SearchHeaderBar() {
     };
   };
 
+  const debounceonScroll = () => {
+    const debounce = setTimeout(() => {
+      if (
+        inputRef?.current?.value &&
+        inputRef.current === document.activeElement
+      ) {
+        inputRef.current.blur();
+        console.log('scroll');
+      }
+    }, 200);
+    return () => {
+      clearTimeout(debounce);
+    };
+  };
+
   useEffect(() => {
     if (router?.query?.keyword) {
       if (typeof router.query.keyword === 'string') {
@@ -84,6 +99,14 @@ export default function SearchHeaderBar() {
       setKeyword('');
     }
   }, [router.pathname, router.query.keyword]);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.addEventListener('scroll', function () {
+        debounceonScroll();
+      });
+    }
+  }, []);
 
   return (
     <>

--- a/components/Organisms/Common/SearchHeaderBar.tsx
+++ b/components/Organisms/Common/SearchHeaderBar.tsx
@@ -81,7 +81,6 @@ export default function SearchHeaderBar() {
         inputRef.current === document.activeElement
       ) {
         inputRef.current.blur();
-        console.log('scroll');
       }
     }, 200);
     return () => {


### PR DESCRIPTION
## 연관 KANBAN
https://kimseyoung.notion.site/QA-e451bd00b35f44068ca3665e61d2c9a6

## 📝 변경한 부분

### [테스트 Flow]
input에 검색어 입력 후 검색 페이지 이동 > 검색 페이지 노출 > 스크롤

### [이슈]
스크롤 시 input에 포커스가 남는 이슈 -> 해당 이슈로 인하여 모바일 기기에서 키보드가 남아있음

### [해결]
스크롤 이벤트가 발생하면 input focus를 해지

## 🖼️ 수정한 화면

| 기존화면 | 수정화면 |
| -------- | -------- |
| 화면캡쳐 | 화면캡쳐 |

## 😵‍💫 고민한 부분과 추가논의 부분