### PR TITLE
[QA-디자인] [리스트] 리스트 하트, 별 영역 제플린과 동일하게 수정

### DIFF
--- a/components/Organisms/List/ListItem/ItemAdditionalInfo.tsx
+++ b/components/Organisms/List/ListItem/ItemAdditionalInfo.tsx
@@ -34,11 +34,11 @@ export default function ItemAdditionalInfo(props: AdditionalInfoProps) {
           ''
         )}
         {listItemAdditionalInfo.grade ? (
-          <FlexBox marginRight="10px" height="12px">
+          <FlexBox alignItems="center" marginRight="10px" height="12px">
             <StarRating
               width="10px"
-              height="10px"
-              viewBox="0 0 10 10"
+              height="12px"
+              viewBox="0 0.5 10 10"
               fill={theme.colors.gray99}
             />
             <Box


### PR DESCRIPTION
## 연관 KANBAN
[[QA > 리스트 > 리스트 하트, 별 영역]](https://kimseyoung.notion.site/e83bdaf852a14f7bb475ed3f8095e46f?v=adeaa436e202487e8d8e09e5b5ac8c92&p=1fcd7ef4cc214bf8b2471b8d9d7a0d37&pm=s)

## 📝 변경한 부분
- 별과 하트 정렬 제플린과 동일하게 맞춤
   -  별 아이콘이 하트 아이콘 보다 상단으로 좀 더 나와있음 (약 0.5px정도)

## 🖼️ 수정한 화면

| 기존화면 | 수정화면 |
| -------- | -------- |
| <img width="506" alt="스크린샷 2023-03-03 오후 7 54 12" src="https://user-images.githubusercontent.com/38105502/222702591-5593e6e1-5652-4b63-9648-5e8341015671.png"> | <img width="544" alt="스크린샷 2023-03-03 오후 4 49 22" src="https://user-images.githubusercontent.com/38105502/222702645-51909ce7-9b93-4201-b054-b51f0f023286.png"> |

## 😵‍💫 고민한 부분과 추가논의 부분
