### PR TITLE
[QA-디자인] [픽] 종료 타이틀 가운데 정렬

### DIFF
--- a/components/Organisms/Pick/PickItem/PickItemImage.tsx
+++ b/components/Organisms/Pick/PickItem/PickItemImage.tsx
@@ -39,11 +39,14 @@ export default function PickItemImage({ presentationImage }: ImagePorps) {
             <Box
               position="absolute"
               top="calc(50% - 16px)"
-              left="calc(50% - 30px)"
+              left="50%"
               color={theme.colors.white}
               fontSize="26px"
               lineHeight="32px"
               zIndex="2"
+              css={css`
+                transform: translateX(-50%);
+              `}
             >
               {presentationImage.backgroundText}
             </Box>


### PR DESCRIPTION
## 연관 KANBAN

## 📝 변경한 부분
픽 페이지 종료 타이틀 가운데 정렬

## 🖼️ 수정한 화면
| 기존화면 | 수정화면 |
| -------- | -------- |
| <img width="239" alt="스크린샷 2023-03-08 오후 9 22 03" src="https://user-images.githubusercontent.com/38105502/223712185-dfa0633f-4c2f-424b-ab1d-94a145ab1d47.png"> | <img width="238" alt="스크린샷 2023-03-08 오후 9 22 31" src="https://user-images.githubusercontent.com/38105502/223712275-6956872c-b6d3-4083-8d37-e718d1a44ea3.png"> |

## 😵‍💫 고민한 부분과 추가논의 부분
