### PR TITLE
[Feat] [팝업 및 모달] 페이지 이동 시 파업 및 모달 유지 이슈 수정

### DIFF
--- a/components/Organisms/Modal/ModalContainer.tsx
+++ b/components/Organisms/Modal/ModalContainer.tsx
@@ -3,16 +3,28 @@ import { useRecoilValue, useSetRecoilState } from 'recoil';
 import ModalBox from 'components/Organisms/Modal/ModalBox';
 import { ModalComponents } from 'constants/type/initialModal';
 import { modalOutState, modalState } from 'states/modal';
+import { useModal } from 'utils/hooks/useModal';
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
 
 export default function ModalContainer() {
   const modals = useRecoilValue(modalState);
   const setModalOutState = useSetRecoilState(modalOutState);
+  const router = useRouter();
+
+  const { offModal } = useModal();
 
   if (modals.length !== 0) {
     setModalOutState(true);
   } else {
     setModalOutState(false);
   }
+
+  useEffect(() => {
+    router.events.on('routeChangeStart', () => {
+      offModal();
+    });
+  }, []);
 
   return (
     <>

--- a/components/Organisms/Modal/ModalContainer.tsx
+++ b/components/Organisms/Modal/ModalContainer.tsx
@@ -24,6 +24,12 @@ export default function ModalContainer() {
     router.events.on('routeChangeStart', () => {
       offModal();
     });
+
+    return () => {
+      router.events.off('routeChangeStart', () => {
+        offModal();
+      });
+    };
   }, []);
 
   return (

--- a/components/Organisms/Popup/PopupRouter.tsx
+++ b/components/Organisms/Popup/PopupRouter.tsx
@@ -31,6 +31,12 @@ const PopupRouter = () => {
     router.events.on('routeChangeStart', () => {
       setPopupName(POPUP_NAME.NULL);
     });
+
+    return () => {
+      router.events.off('routeChangeStart', () => {
+        setPopupName(POPUP_NAME.NULL);
+      });
+    };
   }, []);
 
   switch (popupName) {

--- a/components/Organisms/Popup/PopupRouter.tsx
+++ b/components/Organisms/Popup/PopupRouter.tsx
@@ -1,4 +1,4 @@
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 
 import AlertArchiveCancelConfirmPopup from 'components/Organisms/Popup/AlertArchiveCancelConfirmPopup';
 import AlertArchiveDeletePopup from 'components/Organisms/Popup/AlertArchiveDeletePopup';
@@ -12,16 +12,26 @@ import MyArchiveDetailPopup from 'components/Organisms/Popup/MyArchiveDetailPopu
 import { POPUP_NAME } from 'constants/popupName';
 import { PopupNameState } from 'states';
 import { setPopup } from 'states/popupName';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
 
 const PopupRouter = () => {
-  const popupName = useRecoilValue(PopupNameState);
+  // const popupName = useRecoilValue(PopupNameState);
   const setPopupState = useSetRecoilState(setPopup);
+  const [popupName, setPopupName] = useRecoilState(PopupNameState);
+  const router = useRouter();
 
   if (popupName?.length) {
     setPopupState(true);
   } else {
     setPopupState(false);
   }
+
+  useEffect(() => {
+    router.events.on('routeChangeStart', () => {
+      setPopupName(POPUP_NAME.NULL);
+    });
+  }, []);
 
   switch (popupName) {
     case POPUP_NAME.ALERT_CONFIRM:

--- a/components/Organisms/Popup/PopupRouter.tsx
+++ b/components/Organisms/Popup/PopupRouter.tsx
@@ -16,7 +16,6 @@ import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 
 const PopupRouter = () => {
-  // const popupName = useRecoilValue(PopupNameState);
   const setPopupState = useSetRecoilState(setPopup);
   const [popupName, setPopupName] = useRecoilState(PopupNameState);
   const router = useRouter();

--- a/components/Organisms/Popup/PopupRouter.tsx
+++ b/components/Organisms/Popup/PopupRouter.tsx
@@ -1,4 +1,4 @@
-import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 
 import AlertArchiveCancelConfirmPopup from 'components/Organisms/Popup/AlertArchiveCancelConfirmPopup';
 import AlertArchiveDeletePopup from 'components/Organisms/Popup/AlertArchiveDeletePopup';


### PR DESCRIPTION
## 연관 KANBAN
[[QA > 팝업 및 모달 > 팝업을 띄운 후 페이지 이동 시 팝업 유지 이슈]](https://www.notion.so/kimseyoung/b9b679f2a5e94ffc82f1afd06053d443?pvs=4)

## 📝 변경한 부분
next js에서 제공하는 router event를 활용하여 router가 변경 될 시 팝업을 닫아주는 이벤트 생성
- popup
```
useEffect(() => {
    //routeChangeStart : 경로가 변경되기 시작할때 발생
    router.events.on('routeChangeStart', () => {
      setPopupName(POPUP_NAME.NULL);
    });
		
    // 해당 컴포넌트가 화면에 더 이상 나오지 않으면 이벤트를 멈춰줘야 함
    return () => {
      router.events.off('routeChangeStart', () => {
        setPopupName(POPUP_NAME.NULL);
      });
    };
  }, []);
```
- modal
```
useEffect(() => {
    router.events.on('routeChangeStart', () => {
      offModal();
    });

    // 해당 컴포넌트가 화면에 더 이상 나오지 않으면 이벤트를 멈춰줘야 함
    return () => {
      router.events.off('routeChangeStart', () => {
        offModal();
      });
    };
  }, []);
```
## 😵‍💫 고민한 부분과 추가논의 부분
참고 사이트
[next js 공식 문서](https://nextjs.org/docs/api-reference/next/router#routerevents)
[공식 문서 정리된 블로그](https://im-designloper.tistory.com/102)
