### PR TITLE
[ Fix ][ 홈, 마이페이지] 헤더바 / etc - 커서 css , 마이페이지 탭메뉴 css 

### DIFF
--- a/components/Organisms/Common/HeaderBar.tsx
+++ b/components/Organisms/Common/HeaderBar.tsx
@@ -183,7 +183,7 @@ function HeaderBar() {
         >
           <Box position="relative">
             <Box
-              aria-label="왼쪽 버튼"
+              aria-label="헤더 왼쪽 버튼"
               role="button"
               position="absolute"
               top="13px"
@@ -211,7 +211,7 @@ function HeaderBar() {
             </Box>
             <FlexBox position="absolute" top="15px" right="13px">
               <Box
-                aria-label="오른쪽 버튼"
+                aria-label="헤더 오른쪽 버튼"
                 role="button"
                 width="20px"
                 height="20px"
@@ -219,6 +219,9 @@ function HeaderBar() {
                 onClick={() => {
                   router.push('/search');
                 }}
+                css={css`
+                  cursor: pointer;
+                `}
               >
                 <Image
                   src={WhiteSearch}

--- a/components/Organisms/Common/HeaderBar.tsx
+++ b/components/Organisms/Common/HeaderBar.tsx
@@ -20,13 +20,7 @@ import theme from 'styles/theme';
 const headerLeftIcon = {
   default: <ArrowLeft width="30" height="30" viewBox="-10 -6 30 30" />,
   logo: <Image src={Logo} alt="image" width="136px" height="20px" />,
-  disabled: (
-    <div
-      css={css`
-        cursor: default;
-      `}
-    ></div>
-  ),
+  disabled: <></>,
   privacy: (
     <Box fontSize="16px" fontWeight={500} lineHeight={1.5}>
       개인정보처리방침
@@ -105,9 +99,15 @@ function HeaderBar() {
                     header.headerLeftAction();
                   }
                 }}
-                css={css`
-                  cursor: pointer;
-                `}
+                css={
+                  header.headerLeft === 'disabled'
+                    ? css`
+                        cursor: default;
+                      `
+                    : css`
+                        cursor: pointer;
+                      `
+                }
               >
                 {headerLeftIcon[header.headerLeft ?? 'disabled']}
               </Box>
@@ -137,9 +137,15 @@ function HeaderBar() {
                       router.push('/search');
                     }
                   }}
-                  css={css`
-                    cursor: pointer;
-                  `}
+                  css={
+                    header.headerRight === 'disabled'
+                      ? css`
+                          cursor: default;
+                        `
+                      : css`
+                          cursor: pointer;
+                        `
+                  }
                 >
                   {headerRightIcon[header.headerRight ?? 'search']}
                 </Box>
@@ -153,6 +159,15 @@ function HeaderBar() {
                     onClick={() => {
                       router.push('/');
                     }}
+                    css={
+                      header.headerEnd === 'disabled'
+                        ? css`
+                            cursor: default;
+                          `
+                        : css`
+                            cursor: pointer;
+                          `
+                    }
                   >
                     {headerEndIcon[header.headerEnd]}
                   </Box>
@@ -195,9 +210,15 @@ function HeaderBar() {
                   header.headerLeftAction();
                 }
               }}
-              css={css`
-                cursor: pointer;
-              `}
+              css={
+                header.headerLeft === 'disabled'
+                  ? css`
+                      cursor: default;
+                    `
+                  : css`
+                      cursor: pointer;
+                    `
+              }
             >
               <Image src={WhiteLogo} alt="image" width="136px" height="20px" />
             </Box>
@@ -212,16 +233,21 @@ function HeaderBar() {
             <FlexBox position="absolute" top="15px" right="13px">
               <Box
                 aria-label="헤더 오른쪽 버튼"
-                role="button"
                 width="20px"
                 height="20px"
                 alignItems="center"
                 onClick={() => {
                   router.push('/search');
                 }}
-                css={css`
-                  cursor: pointer;
-                `}
+                css={
+                  header.headerRight === 'disabled'
+                    ? css`
+                        cursor: default;
+                      `
+                    : css`
+                        cursor: pointer;
+                      `
+                }
               >
                 <Image
                   src={WhiteSearch}

--- a/components/Organisms/Home/Module/KeyVisual/index.tsx
+++ b/components/Organisms/Home/Module/KeyVisual/index.tsx
@@ -13,6 +13,9 @@ export default function KeyVisual({ keyVisualDatas, index }: KeyVisualProps) {
   const onIntersect: IntersectionObserverCallback = ([{ isIntersecting }]) => {
     setHeaderState({
       headerLeft: 'logo',
+      headerLeftAction() {
+        router.reload();
+      },
       frontTopTransparent: true,
       transparent: isIntersecting,
     });

--- a/components/Organisms/Home/Module/MonthlyFreeItem/MonthlyFreeItemCard.tsx
+++ b/components/Organisms/Home/Module/MonthlyFreeItem/MonthlyFreeItemCard.tsx
@@ -22,16 +22,25 @@ export default function MonthlyFreeItemCard({
   return (
     <FlexBox width="100%" height="120px" marginBottom="10px">
       <Box
+        aria-label="해당 아이템 링크"
+        role="link"
         width="90px"
         onClick={() => {
           router.push(content.presentationImage.link);
         }}
+        css={css`
+          cursor: pointer;
+        `}
       >
         <Image
           width={90}
           height={120}
           alt="image"
-          src={!content.presentationImage.url ? noImage : content.presentationImage.url}
+          src={
+            !content.presentationImage.url
+              ? noImage
+              : content.presentationImage.url
+          }
         />
       </Box>
       <Box
@@ -46,6 +55,8 @@ export default function MonthlyFreeItemCard({
           {content.typeBadge.text}
         </Tag>
         <Box
+          aria-label="해당 아이템 링크"
+          role="link"
           marginTop="10px"
           width="220px"
           fontSize="13px"
@@ -58,6 +69,7 @@ export default function MonthlyFreeItemCard({
             display: -webkit-box;
             -webkit-line-clamp: 2;
             -webkit-box-orient: vertical;
+            cursor: pointer;
           `}
           onClick={() => {
             router.push(content.title.link);

--- a/components/Organisms/Home/Module/SwipeItem/SwipeItemInfo.tsx
+++ b/components/Organisms/Home/Module/SwipeItem/SwipeItemInfo.tsx
@@ -25,6 +25,8 @@ export default function SwipeItemInfo({
   return (
     <Box paddingTop="20px" width="300px" paddingX="15px">
       <Box
+        aria-label="아이템 타이틀 링크"
+        role="link"
         fontSize="19px"
         fontWeight={500}
         lineHeight={1.37}
@@ -35,6 +37,7 @@ export default function SwipeItemInfo({
           display: -webkit-box;
           -webkit-line-clamp: 2;
           -webkit-box-orient: vertical;
+          cursor: pointer;
         `}
         color={theme.colors.black}
         onClick={() => {

--- a/components/Organisms/MyPage/MyPageInfoFragment.tsx
+++ b/components/Organisms/MyPage/MyPageInfoFragment.tsx
@@ -34,7 +34,7 @@ export default function MyPageInfoFragment() {
         <>
           <Box
             position="sticky"
-            top="calc(45px + env(safe-area-inset-top))"
+            top="calc(44px + env(safe-area-inset-top))"
             background={theme.colors.white}
             zIndex={2}
           >


### PR DESCRIPTION
## 📝 변경한 부분
1. 홈
    - 스와이프 아이템 타이틀 - 커서: 포인터 적용
    - 이달의 무료 아이템 이미지 & 타이틀 - 커서: 포인터 적용
2. 마이페이지
    - 마이페이지 스크롤 시, 탭메뉴 사이 생기는 틈 css 수정
3. 헤더바
    - 헤더바 {오른쪽 || 왼쪽 || 끝} 아이콘 : 'disabled' (공백) 일 경우, 해당영역 커서: default 되도록 

## 😵‍💫 고민한 부분과 추가논의 부분
- 헤더바에서 수정하여 모든 페이지 헤더바 아이콘에 대해 수정할 수 있었습니다
