### PR TITLE
fix: headerRightAction 빈함수 넣어주는 것으로 통일

### DIFF
--- a/components/Organisms/Common/HeaderBar.tsx
+++ b/components/Organisms/Common/HeaderBar.tsx
@@ -124,33 +124,31 @@ function HeaderBar() {
                 top={header.headerRight === 'close' ? '10px' : '6px'}
                 right="10px"
               >
-                {header.headerRightAction && (
-                  <Box
-                    aria-label="오른쪽 버튼"
-                    role="button"
-                    width="30px"
-                    height="30px"
-                    alignItems="center"
-                    onClick={() => {
-                      if (header.headerRightAction) {
-                        header.headerRightAction();
-                      } else {
-                        router.push('/search');
-                      }
-                    }}
-                    css={
-                      header.headerRight === 'disabled'
-                        ? css`
-                            cursor: default;
-                          `
-                        : css`
-                            cursor: pointer;
-                          `
+                <Box
+                  aria-label="오른쪽 버튼"
+                  role="button"
+                  width="30px"
+                  height="30px"
+                  alignItems="center"
+                  onClick={() => {
+                    if (header.headerRightAction) {
+                      header.headerRightAction();
+                    } else {
+                      router.push('/search');
                     }
-                  >
-                    {headerRightIcon[header.headerRight ?? 'search']}
-                  </Box>
-                )}
+                  }}
+                  css={
+                    header.headerRight === 'disabled'
+                      ? css`
+                          cursor: default;
+                        `
+                      : css`
+                          cursor: pointer;
+                        `
+                  }
+                >
+                  {headerRightIcon[header.headerRight ?? 'search']}
+                </Box>
                 {header.headerEnd ? (
                   <Box
                     aria-label="끝 버튼"

--- a/pages/archive/index.tsx
+++ b/pages/archive/index.tsx
@@ -22,6 +22,7 @@ const Archive: NextPage<UserProps> = ({ user }) => {
       }
       return router.push('/mypage');
     },
+    headerRightAction: () => {},
   });
 
   if (!user.isLogin) {

--- a/pages/archive/update.tsx
+++ b/pages/archive/update.tsx
@@ -16,6 +16,7 @@ const ArchiveUpdate: NextPage<UserProps> = ({ user }) => {
     title: '아카이브 수정하기',
     headerRight: 'disabled',
     headerLeftAction: () => router.back(),
+    headerRightAction: () => {},
   });
 
   if (!user.isLogin) {


### PR DESCRIPTION
## 📝 변경한 부분
- headerbarRightIcon `'disabled'` 인데 마우스커서 활성화, 클릭시 서치페이지 이동 이슈 해결법을 
  headerRightAction 빈함수 넣어주는 것으로 통일함.

## 참고 issue
- #243 