### PR TITLE
[ Fix ] 코멘트 디코딩, css 수정

### DIFF
--- a/components/Molecules/Carousel.tsx
+++ b/components/Molecules/Carousel.tsx
@@ -37,7 +37,7 @@ export default function Carousel({
           justifyContent="space-around"
           top="0px"
           right="0px"
-          zIndex="100"
+          zIndex="1"
           backgroundColor={theme.colors.black}
           opacity="0.4"
         >

--- a/components/Organisms/Detail/DetailNavigation.tsx
+++ b/components/Organisms/Detail/DetailNavigation.tsx
@@ -28,7 +28,7 @@ export function DescriptionNavigation({
   return (
     <Box
       position="sticky"
-      top="calc(45px + env(safe-area-inset-top))"
+      top="calc(44px + env(safe-area-inset-top))"
       background={theme.colors.white}
       zIndex={2}
     >

--- a/components/Organisms/Home/Module/RealtimeArchiveItem/RealtimeArchiveItemCard.tsx
+++ b/components/Organisms/Home/Module/RealtimeArchiveItem/RealtimeArchiveItemCard.tsx
@@ -188,7 +188,7 @@ export default function RealTimeArchiveItemCard({
             `}
             overflow="hidden"
           >
-            {archive.introduction.comment}
+            {decodeURIComponent(archive.introduction.comment)}
           </Box>
         ) : (
           <></>

--- a/components/Organisms/Home/ModuleTypes.ts
+++ b/components/Organisms/Home/ModuleTypes.ts
@@ -94,7 +94,7 @@ export type RealTimeArchiveItemCardProps = {
   introduction: {
     title: { link: string; value: string };
     places?: string;
-    comment?: string;
+    comment: string;
   };
   metaData: {
     user: { name: string; photoUrl?: string };

--- a/components/Organisms/MyPage/Archive/ListCard.tsx
+++ b/components/Organisms/MyPage/Archive/ListCard.tsx
@@ -120,7 +120,7 @@ export default function ListCard(props: ItemProps) {
               -webkit-box-orient: vertical;
             `}
           >
-            {content.comment}
+            {decodeURIComponent(content.comment)}
           </Box>
           <Box marginTop="11px" display={content?.places ? 'block' : 'none'}>
             <FlexBox alignItems="center">

--- a/components/Organisms/Popup/MyArchiveDetailPopup.tsx
+++ b/components/Organisms/Popup/MyArchiveDetailPopup.tsx
@@ -131,7 +131,9 @@ const MyArchiveDetailPopup = () => {
                       textAlign="left"
                       color={theme.colors.white}
                     >
-                      <InnerHTML data={archiveData?.comment} />
+                      <InnerHTML
+                        data={decodeURIComponent(archiveData?.comment)}
+                      />
                     </Box>
                   )}
                 </Box>


### PR DESCRIPTION
## 📝 변경한 부분
- 코멘트 디코딩 추가 
  - 홈> 실시간 아카이브
  -  마이페이지 > 마이아카이브 디테일  
  - 마이페이지 > 마이아카이브리스트

- css 수정
  - 아이템상세페이지  
  - 캐러셀 인디케이터 z-index 수정
  
  | 수정 전 | 수정 후 |
  |----------|----------|
  |<img src="https://user-images.githubusercontent.com/32234327/224000122-88ddb606-aa62-424e-a631-7d1955a98300.png" width="300px">|<img src="https://user-images.githubusercontent.com/32234327/223999778-497f7cd3-7d20-4268-ac28-46558697f5d6.png" width="300px">|