### PR TITLE
[ Feature ] [이미지 캐러셀] 마우스 드래그 이용한 이미지 슬라이딩

### DIFF
--- a/components/Molecules/Carousel.tsx
+++ b/components/Molecules/Carousel.tsx
@@ -23,94 +23,65 @@ export default function Carousel({
     setNowIndex(index);
   };
 
-  // useRef 훅 예제
-  // const [offsetLeft, setHeight] = useState(0);
-  // const ref = useRef<any>(null);
-
-  // useEffect(() => {
-  //   if (ref?.current?.offsetHeight) {
-  //     setHeight(ref.current.offsetHeight);
-  //   }
-  // }, []);
-
   //TODO: 마우스 클릭하여 드래그 horizontal 스크롤
 
   // 아이템 감싸는 부모 ele
   // const slider = document.querySelector('.items');
-  const sliderRef = useRef<any>(null);
-
-  const [nowOffsetLeft, setNowOffsetLeft] = useState(0);
-
-  useEffect(() => {
-    if (sliderRef?.current?.offsetLeft) {
-      setNowOffsetLeft(sliderRef.current.offsetLeft);
-    }
-  }, []);
 
   const test = () => {
-    console.log(sliderRef?.current.offsetLeft);
+    console.log(sliderRef?.current.scrollLeft);
   };
+
+  // let isDown = false;
+  // let startX: number;
+  // let scrollLeft: number;
+  // const [walk, setWalk] = useState(0);
+  // const [updatedScrollLeft, setUpdatedScrollLeft] = useState(0);
+  // const [startX, setStartX] = useState(0);
+  // const [isDown, setIsDown] = useState(false);
+  const sliderRef = useRef<any>(null);
+
+  let isDown = false;
+  let startX = 0;
+  let updatedScrollLeft = 0;
+  let walk = 0;
 
   const mouseDragScroll = () => {
-    let isDown = false;
-    let startX: number;
-    let scrollLeft: number;
-
-    // slider?.addEventListener('mousedown', (e) => {
-    //   isDown = true;
-    //   slider.classList.add('active');
-    //   startX = e.pageX - slider.offsetLeft;
-    //   scrollLeft = slider.scrollLeft;
-    // });
-
-    sliderRef?.current.addEventListener('mousedown', (e: React.MouseEvent) => {
+    sliderRef.current.addEventListener('mousedown', (e: React.MouseEvent) => {
       isDown = true;
-      startX = e.pageX - sliderRef?.current?.offsetLeft; // 브라우저 x 축 마우스 좌표 -
-      scrollLeft = sliderRef.current.scrollLeft;
-      console.log(`마우스클릭위치 scrollLeft : ${scrollLeft}`);
+      startX = e.pageX - sliderRef.current.offsetLeft;
+      updatedScrollLeft = sliderRef.current.scrollLeft;
     });
 
-    // slider?.addEventListener('mouseleave', () => {
-    //   isDown = false;
-    //   slider.classList.remove('active');
-    // });
-
-    sliderRef?.current?.addEventListener('mouseleave', () => {
+    sliderRef.current.addEventListener('mouseup', () => {
       isDown = false;
+      console.log('mouseUp');
     });
 
-    // slider?.addEventListener('mouseup', () => {
-    //   isDown = false;
-    //   slider.classList.remove('active');
-    // });
-
-    sliderRef?.current?.addEventListener('mouseup', () => {
+    sliderRef.current.addEventListener('mouseleave', () => {
       isDown = false;
+      console.log('mouseleave');
     });
 
-    // grap and scroll
-    // slider?.addEventListener('mousemove', (e) => {
-    //   if (!isDown) return;
-    //   e.preventDefault();
-    //   const x = e.pageX - slider.offsetLeft;
-    //   const walk = (x - startX) * 3; // scroll-fast
-    //   slider.scrollLeft -= walk;
-    // });
-
-    sliderRef?.current?.addEventListener('mousemove', (e: React.MouseEvent) => {
-      if (!isDown) return; // 안누르고 마우스 움직일때.
+    sliderRef.current.addEventListener('mousemove', (e: React.MouseEvent) => {
+      if (!isDown) return null;
       e.preventDefault();
-      console.log(`pageX: ${e.pageX}`); // 브라우저 x 축에서의 마우스좌표
-      console.log(
-        `sliderRef?.current?.offsetLeft: ${sliderRef?.current?.offsetLeft}`, // 현재 스크롤 x 위치
-      );
-      const x = e.pageX - sliderRef?.current?.offsetLeft;
-      console.log(`x: ${x}`); // 현재마우스좌표 - 스크롤 위치
-      const walk = x - startX; // 이동한거리. 마이너스값이면 왼쪽으로 이동, 플러스면 오른쪽으로 이동
-      setNowOffsetLeft(scrollLeft - walk);
-      // console.log(`현재 이동하는 스크롤left : ${nowOffsetLeft}`);
+      console.log(`walk: ${walk}`);
+      // setWalk(e.pageX - sliderRef.current.offsetLeft - startX);
+      // setUpdatedScrollLeft(updatedScrollLeft + walk);
+
+      walk = e.pageX - sliderRef.current.offsetLeft - startX;
+      sliderRef.current.scrollLeft += updatedScrollLeft + walk;
+      console.log(sliderRef.current.scrollLeft);
     });
   };
+
+  useEffect(() => {
+    if (sliderRef) {
+      console.log('sliderRef 있음');
+      mouseDragScroll();
+    }
+  });
 
   return (
     <Box position="relative">

--- a/components/Molecules/Carousel.tsx
+++ b/components/Molecules/Carousel.tsx
@@ -21,6 +21,39 @@ export default function Carousel({
   const handleIndicator = (index: number) => {
     setNowIndex(index);
   };
+
+  //레퍼런스 코드
+  // const slider = document.querySelector('.items');
+  // let isDown = false;
+  // let startX;
+  // let scrollLeft;
+
+  // slider.addEventListener('mousedown', (e) => {
+  //   isDown = true;
+  //   slider.classList.add('active');
+  //   startX = e.pageX - slider.offsetLeft;
+  //   scrollLeft = slider.scrollLeft;
+  // });
+  // slider.addEventListener('mouseleave', () => {
+  //   isDown = false;
+  //   slider.classList.remove('active');
+  // });
+  // slider.addEventListener('mouseup', () => {
+  //   isDown = false;
+  //   slider.classList.remove('active');
+  // });
+  // slider.addEventListener('mousemove', (e) => {
+  //   if(!isDown) return;
+  //   e.preventDefault();
+  //   const x = e.pageX - slider.offsetLeft;
+  //   const walk = (x - startX) * 3; //scroll-fast
+  //   slider.scrollLeft = scrollLeft - walk;
+  //   console.log(`처음 scrollLeft: ${scrollLeft}`)
+  //   console.log(`현재 scrollLeft: ${slider.scrollLeft}`)
+  //   console.log(walk);
+
+  // });
+
   return (
     <Box position="relative">
       {imgUrlArr.length === 0 && (

--- a/components/Molecules/Carousel.tsx
+++ b/components/Molecules/Carousel.tsx
@@ -1,10 +1,11 @@
 import { css } from '@emotion/react';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { FlexBox, Box } from 'components/Atoms';
 import CarouselItem from 'components/Molecules/CarouselItem';
 import theme from 'styles/theme';
 import { Loader } from 'components/Atoms/Loader';
+import { start } from 'repl';
 
 export default function Carousel({
   imgUrlArr,
@@ -22,37 +23,94 @@ export default function Carousel({
     setNowIndex(index);
   };
 
-  //레퍼런스 코드
+  // useRef 훅 예제
+  // const [offsetLeft, setHeight] = useState(0);
+  // const ref = useRef<any>(null);
+
+  // useEffect(() => {
+  //   if (ref?.current?.offsetHeight) {
+  //     setHeight(ref.current.offsetHeight);
+  //   }
+  // }, []);
+
+  //TODO: 마우스 클릭하여 드래그 horizontal 스크롤
+
+  // 아이템 감싸는 부모 ele
   // const slider = document.querySelector('.items');
-  // let isDown = false;
-  // let startX;
-  // let scrollLeft;
+  const sliderRef = useRef<any>(null);
 
-  // slider.addEventListener('mousedown', (e) => {
-  //   isDown = true;
-  //   slider.classList.add('active');
-  //   startX = e.pageX - slider.offsetLeft;
-  //   scrollLeft = slider.scrollLeft;
-  // });
-  // slider.addEventListener('mouseleave', () => {
-  //   isDown = false;
-  //   slider.classList.remove('active');
-  // });
-  // slider.addEventListener('mouseup', () => {
-  //   isDown = false;
-  //   slider.classList.remove('active');
-  // });
-  // slider.addEventListener('mousemove', (e) => {
-  //   if(!isDown) return;
-  //   e.preventDefault();
-  //   const x = e.pageX - slider.offsetLeft;
-  //   const walk = (x - startX) * 3; //scroll-fast
-  //   slider.scrollLeft = scrollLeft - walk;
-  //   console.log(`처음 scrollLeft: ${scrollLeft}`)
-  //   console.log(`현재 scrollLeft: ${slider.scrollLeft}`)
-  //   console.log(walk);
+  const [nowOffsetLeft, setNowOffsetLeft] = useState(0);
 
-  // });
+  useEffect(() => {
+    if (sliderRef?.current?.offsetLeft) {
+      setNowOffsetLeft(sliderRef.current.offsetLeft);
+    }
+  }, []);
+
+  const test = () => {
+    console.log(sliderRef?.current.offsetLeft);
+  };
+
+  const mouseDragScroll = () => {
+    let isDown = false;
+    let startX: number;
+    let scrollLeft: number;
+
+    // slider?.addEventListener('mousedown', (e) => {
+    //   isDown = true;
+    //   slider.classList.add('active');
+    //   startX = e.pageX - slider.offsetLeft;
+    //   scrollLeft = slider.scrollLeft;
+    // });
+
+    sliderRef?.current.addEventListener('mousedown', (e: React.MouseEvent) => {
+      isDown = true;
+      startX = e.pageX - sliderRef?.current?.offsetLeft; // 브라우저 x 축 마우스 좌표 -
+      scrollLeft = sliderRef.current.scrollLeft;
+      console.log(`마우스클릭위치 scrollLeft : ${scrollLeft}`);
+    });
+
+    // slider?.addEventListener('mouseleave', () => {
+    //   isDown = false;
+    //   slider.classList.remove('active');
+    // });
+
+    sliderRef?.current?.addEventListener('mouseleave', () => {
+      isDown = false;
+    });
+
+    // slider?.addEventListener('mouseup', () => {
+    //   isDown = false;
+    //   slider.classList.remove('active');
+    // });
+
+    sliderRef?.current?.addEventListener('mouseup', () => {
+      isDown = false;
+    });
+
+    // grap and scroll
+    // slider?.addEventListener('mousemove', (e) => {
+    //   if (!isDown) return;
+    //   e.preventDefault();
+    //   const x = e.pageX - slider.offsetLeft;
+    //   const walk = (x - startX) * 3; // scroll-fast
+    //   slider.scrollLeft -= walk;
+    // });
+
+    sliderRef?.current?.addEventListener('mousemove', (e: React.MouseEvent) => {
+      if (!isDown) return; // 안누르고 마우스 움직일때.
+      e.preventDefault();
+      console.log(`pageX: ${e.pageX}`); // 브라우저 x 축에서의 마우스좌표
+      console.log(
+        `sliderRef?.current?.offsetLeft: ${sliderRef?.current?.offsetLeft}`, // 현재 스크롤 x 위치
+      );
+      const x = e.pageX - sliderRef?.current?.offsetLeft;
+      console.log(`x: ${x}`); // 현재마우스좌표 - 스크롤 위치
+      const walk = x - startX; // 이동한거리. 마이너스값이면 왼쪽으로 이동, 플러스면 오른쪽으로 이동
+      setNowOffsetLeft(scrollLeft - walk);
+      // console.log(`현재 이동하는 스크롤left : ${nowOffsetLeft}`);
+    });
+  };
 
   return (
     <Box position="relative">
@@ -103,7 +161,8 @@ export default function Carousel({
         css={css`
           scroll-snap-type: x mandatory;
         `}
-        ref={rootRef}
+        ref={sliderRef}
+        onClick={mouseDragScroll}
       >
         <FlexBox height="inherit" width="fit-content" flexDirection="row">
           {imgUrlArr.map((imgUrl, _index) => (
@@ -111,7 +170,7 @@ export default function Carousel({
               itemOrder={_index}
               key={_index}
               imgUrl={imgUrl}
-              rootRef={rootRef}
+              rootRef={sliderRef}
               handleIndicator={handleIndicator}
               width={width}
               height={height}

--- a/components/Molecules/CarouselItem.tsx
+++ b/components/Molecules/CarouselItem.tsx
@@ -33,20 +33,20 @@ export default function CarouselItem({
 
   const setTarget = useIntersectionObserver({
     root: rootRef.current,
-    threshold: 0.9,
+    threshold: 0.2,
     onIntersect,
   });
 
   return (
     <Box
-      css={css`
-        scroll-snap-align: start;
-      `}
       width={width}
       maxWidth={theme.view.webView}
       height={height}
       position="relative"
       ref={setTarget}
+      css={css`
+        scroll-snap-align: end;
+      `}
     >
       <Image src={imgUrl} alt="image" layout="fill" />
       {dimOption ? <CarouselDim height={height} /> : <></>}

--- a/components/Organisms/Home/Module/SwipeItem/MainSwipeImage.tsx
+++ b/components/Organisms/Home/Module/SwipeItem/MainSwipeImage.tsx
@@ -4,15 +4,16 @@ import Image from 'next/image';
 import { Box } from 'components/Atoms';
 export default function MainSwipeImage({ src }: { src: string }) {
   return (
-    <Box
-      width="315px"
-      height="420px"
-      marginRight="15px"
-      css={css`
-        scroll-snap-align: start;
-      `}
-    >
-      <Image width={315} height={420} alt="image" src={src} />
+    <Box width="315px" height="420px" marginRight="15px">
+      <Image
+        width={315}
+        height={420}
+        alt="image"
+        src={src}
+        css={css`
+          scroll-snap-align: start;
+        `}
+      />
     </Box>
   );
 }

--- a/components/Organisms/Home/Module/SwipeItem/SubSwipeImage.tsx
+++ b/components/Organisms/Home/Module/SwipeItem/SubSwipeImage.tsx
@@ -4,14 +4,16 @@ import Image from 'next/image';
 import { Box } from 'components/Atoms';
 export default function SubSwipeImage({ src }: { src: string }) {
   return (
-    <Box
-      paddingY="37px"
-      marginRight="15px"
-      css={css`
-        scroll-snap-align: start;
-      `}
-    >
-      <Image width={260} height={347} alt="image" src={src} />
+    <Box paddingY="37px" marginRight="15px">
+      <Image
+        width={260}
+        height={347}
+        alt="image"
+        src={src}
+        css={css`
+          scroll-snap-align: start;
+        `}
+      />
     </Box>
   );
 }

--- a/components/Organisms/Home/Module/SwipeItem/UnbalencedSwiper.tsx
+++ b/components/Organisms/Home/Module/SwipeItem/UnbalencedSwiper.tsx
@@ -3,6 +3,7 @@ import { css } from '@emotion/react';
 import { Box, FlexBox } from 'components/Atoms';
 import MainSwipeImage from 'components/Organisms/Home/Module/SwipeItem/MainSwipeImage';
 import SubSwipeImage from 'components/Organisms/Home/Module/SwipeItem/SubSwipeImage';
+import { useRef, useState } from 'react';
 import theme from 'styles/theme';
 
 export default function UnbalencedSwiper({
@@ -12,6 +13,43 @@ export default function UnbalencedSwiper({
   thumbnailPhotoUrl: string;
   photoUrls: string[];
 }) {
+  //마우스 클릭하여 드래그 horizontal 스크롤
+  const sliderRef = useRef<any>();
+  const [isGrabbing, setIsGrabbing] = useState(false);
+  const [walk, setWalk] = useState(0);
+  const [scrollLeft, setScrollLeft] = useState(0);
+  const [startX, setStartX] = useState(0);
+
+  const handleMouseUp = () => {
+    sliderRef.current.style.cursor = '-webkit-grab';
+    sliderRef.current.style.scrollSnapType = 'x mandatory';
+    setIsGrabbing(false);
+  };
+
+  const handleMouseLeave = () => {
+    sliderRef.current.style.cursor = '-webkit-grab';
+    sliderRef.current.style.scrollSnapType = 'none';
+    setIsGrabbing(false);
+  };
+
+  const handleMouseDown = (e: React.MouseEvent) => {
+    sliderRef.current.style.cursor = 'grabb-webkit-grabbing';
+    sliderRef.current.style.scrollSnapType = 'none';
+    setIsGrabbing(true);
+    setStartX(e.pageX - sliderRef.current.offsetLeft); // 움직이기 전 offSetLeft 지점
+    setScrollLeft(sliderRef.current.scrollLeft); // 움직이기전 스크롤왼쪽위치
+  };
+
+  const handleMouseMove = (e: React.MouseEvent) => {
+    if (!isGrabbing) return null; //잡으면서 움직이는 상태인지 판단위해
+    e.preventDefault(); // 드래그 고스트 효과 없애기
+    setWalk(e.pageX - startX - sliderRef.current.offsetLeft); // 움직인 후 offSetLeft 지점
+    //스크롤왼쪽위치 업데이트
+    sliderRef.current.scrollLeft = scrollLeft - walk * 5;
+    sliderRef.current.style.cursor = '-webkit-grabbing';
+    sliderRef.current.style.scrollSnapType = 'none';
+  };
+
   return (
     <Box
       marginTop="60px"
@@ -20,8 +58,14 @@ export default function UnbalencedSwiper({
       height="420px"
       overflowY="hidden"
       overflowX="scroll"
+      ref={sliderRef}
+      onMouseDown={handleMouseDown}
+      onMouseUp={handleMouseUp}
+      onMouseLeave={handleMouseLeave}
+      onMouseMove={handleMouseMove}
       css={css`
-        scroll-snap-type: x mandatory;
+        cursor: -webkit-grab;
+        // scroll-snap-type: x mandatory;
       `}
     >
       <FlexBox width="max-content" flexDirection="row">


### PR DESCRIPTION
## 연관 KANBAN
[이미지 캐러셀 드래그 가능하도록](https://www.notion.so/kimseyoung/Home-Swipe-Item-f20619593e5640f6860bbcb119b2c2ed?pvs=4)

## 📝 변경한 부분
- 마우스 드래그 동작으로 이미지 슬라이딩 가능 :: MouseEvent, useRef 
- 마우스이벤트를 통한 css 동적 변경 :: 마우스커서-grab/grabbing, scroll-snap-type .. 
  - scroll-snap-type  + 계산한 scroll 관련 값에 숫자 곱해 빠른 스크롤동작처럼 보이게 함.
  
- 적용된 곳
  - 홈 > UnbalanceSwipeItem (스와이프 전시 아이템) 
  - 전시아이템 상세페에지 > 아카이브 > 이미지 캐러셀
  - 마이아카이브 디테일 팝업 > 이미지 캐러셀

## 🖼️ 수정한 화면
| 수정화면 |
| -------- |
| <img src="https://user-images.githubusercontent.com/32234327/224496418-b06ac5a9-8ff4-4bf8-870c-e132dce4a0db.gif" width="300px">| 
| -------- |
| <img src="https://user-images.githubusercontent.com/32234327/224496450-781640e3-3c58-44e9-a84e-dc4c70c975d6.gif" width="300px"> | 
| -------- |
| <img src="https://user-images.githubusercontent.com/32234327/224496472-fa2d9554-ae7c-481e-9813-c4fe64581dfb.gif" width="300px"> | 
| -------- |
|<img src="https://user-images.githubusercontent.com/32234327/224496486-a24679da-7883-445c-98e3-7513b8f4543d.gif" width="300px"> | 


## 😵‍💫 고민한 부분과 추가논의 부분
-  스크롤 이벤트 발생 횟수가 많아 throttling 추가 필요

## 📖참고자료
https://codepen.io/thenutz/pen/VwYeYEE?editors=0011
https://web.dev/css-scroll-snap/
https://coding-time.co/scroll-events-react-hooks/
https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetLeft
https://react.vlpt.us/basic/12-variable-with-useRef.html
https://stackoverflow.com/questions/60513173/how-to-add-an-event-listener-to-useref-in-useeffect








