### PR TITLE
[QA-디자인] [픽] 종료 및 D-day 텍스트 폰트 사이즈 변경

### DIFF
--- a/components/Organisms/Pick/PickItem/PickItemImage.tsx
+++ b/components/Organisms/Pick/PickItem/PickItemImage.tsx
@@ -41,7 +41,7 @@ export default function PickItemImage({ presentationImage }: ImagePorps) {
               top="calc(50% - 16px)"
               left="50%"
               color={theme.colors.white}
-              fontSize="26px"
+              fontSize="22px"
               lineHeight="32px"
               zIndex="2"
               css={css`


### PR DESCRIPTION
## 연관 KANBAN
[[픽 > 종료 및 D-day 텍스트 폰트 사이즈 변경]](https://www.notion.so/kimseyoung/eb9041818d7449ba907e7961e810d7c3?pvs=4)

## 📝 변경한 부분
폰트사이즈 26px -> 22px 변경

## 🖼️ 수정한 화면

| 기존화면 | 수정화면 |
| -------- | -------- |
| <img width="231" alt="스크린샷 2023-03-13 오후 10 00 54" src="https://user-images.githubusercontent.com/38105502/224709251-565adb2e-e37f-413d-af7b-426120c159b5.png"> | <img width="236" alt="스크린샷 2023-03-13 오후 10 01 07" src="https://user-images.githubusercontent.com/38105502/224709210-5da7eec0-e7e0-442e-8441-f2bcdf591183.png"> |

## 😵‍💫 고민한 부분과 추가논의 부분
